### PR TITLE
Redesign /voyages search page with new selector bar

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "nuxt-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/app/components/content/search/VoyageSelectorBar.vue
+++ b/app/components/content/search/VoyageSelectorBar.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="selector">
+  <div class="selector ">
     <!-- ============ DESKTOP ============ -->
     <template v-if="mdAndUp">
-      <div class="bar">
+      <div class="bar text-primary">
         <button
           v-for="seg in segments"
           :key="seg.key"
@@ -203,7 +203,7 @@
       <button
         v-for="seg in segments"
         :key="seg.key"
-        class="prow"
+        class="prow "
         type="button"
         @click="sheet = seg.key"
       >
@@ -547,7 +547,7 @@ function toggleSegment(seg) {
   --teal: #2B4C52;
   --or: #DE5E2C;
   --gt: #E7EEED;
-  --t1: #222223;
+  --t1: var(--text-primary);
   --t2: #5d6566;
   --t3: #9aa0a1;
   --bd1: rgba(43, 76, 82, .12);

--- a/app/components/content/search/VoyageSelectorBar.vue
+++ b/app/components/content/search/VoyageSelectorBar.vue
@@ -1,0 +1,825 @@
+<template>
+  <div class="selector">
+    <!-- ============ DESKTOP ============ -->
+    <template v-if="mdAndUp">
+      <div class="bar">
+        <button
+          v-for="seg in segments"
+          :key="seg.key"
+          class="seg"
+          :class="{ on: openSegment === seg.key }"
+          type="button"
+          @click="toggleSegment(seg.key)"
+        >
+          <v-icon
+            :icon="seg.icon"
+            class="lead-i"
+          />
+          <span class="seg-txt">
+            <span class="c">{{ seg.cap }}</span>
+            <span class="v">{{ seg.label }}</span>
+          </span>
+          <v-icon
+            :icon="openSegment === seg.key ? mdiChevronUp : mdiChevronDown"
+            class="chev"
+          />
+        </button>
+      </div>
+
+      <Transition name="panel">
+        <div
+          v-if="openSegment"
+          class="panel"
+        >
+          <div class="panel-body">
+          <!-- Destination -->
+        <template v-if="openSegment === 'dest'">
+          <div class="quick">
+            <button
+              v-for="q in scopeButtons"
+              :key="q"
+              class="qbtn"
+              :class="{ on: scope === q }"
+              type="button"
+              @click="scope = q"
+            >
+              {{ q }}
+            </button>
+          </div>
+          <p class="affine">
+            Affinez par destination :
+          </p>
+          <template
+            v-for="grp in destinationsByRegion"
+            :key="grp.nom"
+          >
+            <p class="reg">
+              {{ clean(grp.nom) === 'France' ? 'France · régions' : grp.nom }}
+            </p>
+            <div class="grid">
+              <button
+                v-for="d in grp.destinations"
+                :key="d.slug"
+                class="thumb"
+                :class="{ on: selDest.includes(d.slug) }"
+                type="button"
+                @click="toggleDest(d.slug)"
+              >
+                <span
+                  class="ph"
+                  :style="thumbBg(d)"
+                >
+                  <v-icon
+                    v-if="!d.image?.asset?._ref"
+                    :icon="mdiMapMarker"
+                  />
+                </span>
+                <span class="scrim" />
+                <span class="badge">{{ d.count }} voyage{{ d.count > 1 ? 's' : '' }}</span>
+                <span
+                  v-if="selDest.includes(d.slug)"
+                  class="chk"
+                >
+                  <v-icon
+                    :icon="mdiCheck"
+                    size="14"
+                    color="white"
+                  />
+                </span>
+                <span class="name">{{ d.title }}</span>
+              </button>
+            </div>
+          </template>
+        </template>
+
+        <!-- Type de voyage -->
+        <template v-else-if="openSegment === 'type'">
+          <div class="quick">
+            <button
+              class="qbtn"
+              :class="{ on: !selType }"
+              type="button"
+              @click="setType('')"
+            >
+              Tous
+            </button>
+            <button
+              class="qbtn"
+              :class="{ on: selType === travelTypes.group }"
+              type="button"
+              @click="setType(travelTypes.group)"
+            >
+              Petit groupe
+            </button>
+            <button
+              class="qbtn"
+              :class="{ on: selType === travelTypes.individual }"
+              type="button"
+              @click="setType(travelTypes.individual)"
+            >
+              Privatisable
+            </button>
+          </div>
+          <p class="affine">
+            Affinez par activité :
+          </p>
+          <div class="cgrid">
+            <button
+              v-for="c in categories"
+              :key="c.slug"
+              class="citem"
+              :class="{ on: selActivities.includes(c.slug) }"
+              type="button"
+              @click="toggleActivity(c.slug)"
+            >
+              {{ c.title.trim() }}
+            </button>
+          </div>
+        </template>
+
+        <!-- Période -->
+        <template v-else>
+          <div class="quick">
+            <button
+              class="qbtn"
+              :class="{ on: selMonths.length === 0 }"
+              type="button"
+              @click="clearSeason()"
+            >
+              Toute l'année
+            </button>
+            <button
+              v-for="(_months, name) in SEASONS"
+              :key="name"
+              class="qbtn"
+              :class="{ on: isSeasonOn(name) }"
+              type="button"
+              @click="setSeason(name)"
+            >
+              {{ name }}
+            </button>
+          </div>
+          <p class="affine">
+            Mois précis :
+          </p>
+          <div class="cgrid months">
+            <button
+              v-for="(m, i) in MONTHS"
+              :key="i"
+              class="citem center"
+              :class="{ on: selMonths.includes(i + 1) }"
+              type="button"
+              @click="toggleMonth(i + 1)"
+            >
+              {{ m }}
+            </button>
+          </div>
+        </template>
+
+          </div>
+
+          <div class="foot">
+            <button
+              class="clear"
+              type="button"
+              @click="clearPanel(openSegment)"
+            >
+            Tout effacer
+          </button>
+          <button
+            class="go"
+            type="button"
+            @click="openSegment = null"
+          >
+            Voir les {{ liveCount }} voyage{{ liveCount > 1 ? 's' : '' }}
+          </button>
+        </div>
+        </div>
+      </Transition>
+    </template>
+
+    <!-- ============ MOBILE ============ -->
+    <template v-else>
+      <button
+        v-for="seg in segments"
+        :key="seg.key"
+        class="prow"
+        type="button"
+        @click="sheet = seg.key"
+      >
+        <v-icon
+          :icon="seg.icon"
+          class="lead-i"
+        />
+        <span class="seg-txt">
+          <span class="c">{{ seg.cap }}</span>
+          <span class="v">{{ seg.label }}</span>
+        </span>
+        <v-icon
+          :icon="mdiChevronRight"
+          class="chev"
+        />
+      </button>
+
+      <v-bottom-sheet v-model="sheetOpen">
+        <div class="sheet">
+          <div class="handle" />
+          <h5>{{ sheetTitle }}</h5>
+          <div class="schips">
+            <!-- Destination -->
+            <template v-if="sheet === 'dest'">
+              <button
+                v-for="q in scopeButtons"
+                :key="q"
+                class="schip"
+                :class="{ scope: scope === q }"
+                type="button"
+                @click="scope = q"
+              >
+                {{ q }}
+              </button>
+              <div class="sdiv" />
+              <button
+                v-for="d in mobileDests"
+                :key="d.slug"
+                class="schip"
+                :class="{ on: selDest.includes(d.slug) }"
+                type="button"
+                @click="toggleDest(d.slug)"
+              >
+                <span
+                  class="dot"
+                  :style="{ background: regionColor(d.regionNom) }"
+                />
+                {{ d.title }}
+              </button>
+            </template>
+
+            <!-- Type -->
+            <template v-else-if="sheet === 'type'">
+              <button
+                class="schip"
+                :class="{ on: selType === travelTypes.group }"
+                type="button"
+                @click="setType(travelTypes.group)"
+              >
+                Petit groupe
+              </button>
+              <button
+                class="schip"
+                :class="{ on: selType === travelTypes.individual }"
+                type="button"
+                @click="setType(travelTypes.individual)"
+              >
+                Privatisable
+              </button>
+              <div class="sdiv" />
+              <button
+                v-for="c in categories"
+                :key="c.slug"
+                class="schip"
+                :class="{ on: selActivities.includes(c.slug) }"
+                type="button"
+                @click="toggleActivity(c.slug)"
+              >
+                {{ c.title.trim() }}
+              </button>
+            </template>
+
+            <!-- Période -->
+            <template v-else>
+              <button
+                v-for="(_months, name) in SEASONS"
+                :key="name"
+                class="schip"
+                :class="{ on: isSeasonOn(name) }"
+                type="button"
+                @click="setSeason(name)"
+              >
+                {{ name }}
+              </button>
+              <div class="sdiv" />
+              <button
+                v-for="(m, i) in MONTHS"
+                :key="i"
+                class="schip"
+                :class="{ on: selMonths.includes(i + 1) }"
+                type="button"
+                @click="toggleMonth(i + 1)"
+              >
+                {{ m }}
+              </button>
+            </template>
+          </div>
+          <button
+            class="go"
+            type="button"
+            @click="sheet = null"
+          >
+            Voir les {{ liveCount }} voyage{{ liveCount > 1 ? 's' : '' }}
+          </button>
+        </div>
+      </v-bottom-sheet>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import {
+  mdiMapSearchOutline, mdiBagPersonalOutline, mdiCalendarMonthOutline,
+  mdiChevronDown, mdiChevronUp, mdiChevronRight, mdiCheck, mdiMapMarker,
+} from '@mdi/js'
+import { useDisplay } from 'vuetify'
+import { useVoyageFilters } from '~/composables/useVoyageFilters'
+import { getImageUrl } from '~/utils/getImageUrl'
+
+const props = defineProps({
+  destinations: { type: Array, default: () => [] },
+  regions: { type: Array, default: () => [] },
+  categories: { type: Array, default: () => [] },
+  travelTypes: { type: Object, default: () => ({}) },
+  allVoyages: { type: Array, default: () => [] },
+})
+
+const route = useRoute()
+const router = useRouter()
+const { mdAndUp } = useDisplay()
+const { countMatching } = useVoyageFilters()
+
+const REGION_ORDER = ['France', 'Europe', 'Asie', 'Afrique', 'Amérique du Nord', 'Amérique Centrale', 'Amérique du Sud', 'Moyen-Orient']
+const REGION_COLOR = {
+  'France': '#2B4C52',
+  'Europe': '#378ADD',
+  'Asie': '#D85A30',
+  'Afrique': '#BA7517',
+  'Amérique du Nord': '#1D9E75',
+  'Amérique Centrale': '#1D9E75',
+  'Amérique du Sud': '#1D9E75',
+  'Moyen-Orient': '#8a6a2a',
+}
+const SEASONS = {
+  'Printemps': [3, 4, 5],
+  'Été': [6, 7, 8],
+  'Automne': [9, 10, 11],
+  'Hiver': [12, 1, 2],
+}
+const MONTHS = ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Août', 'Sep', 'Oct', 'Nov', 'Déc']
+
+// UI-only state
+const openSegment = ref(null) // desktop dropdown: 'dest' | 'type' | 'per'
+const sheet = ref(null) // mobile bottom-sheet segment
+const scope = ref('Toutes')
+
+const sheetOpen = computed({
+  get: () => !!sheet.value,
+  set: (v) => { if (!v) sheet.value = null },
+})
+
+// --- selections derived from route.query (single source of truth) ---
+const selDest = computed(() => (route.query.destination ? String(route.query.destination).split(',').filter(Boolean) : []))
+const selType = computed(() => route.query.travelType || '')
+const selActivities = computed(() => (route.query.activities ? String(route.query.activities).split(',').filter(Boolean) : []))
+const selMonths = computed(() => (route.query.from ? String(route.query.from).split(',').map(Number).filter(n => n > 0 && n <= 12) : []))
+
+const ctx = computed(() => ({
+  destinations: props.destinations,
+  regions: props.regions,
+  travelTypes: props.travelTypes,
+}))
+
+const liveCount = computed(() => countMatching(props.allVoyages, {
+  destinations: selDest.value,
+  travelType: selType.value,
+  from: route.query.from || '',
+  activities: selActivities.value,
+}, ctx.value))
+
+const segments = computed(() => [
+  { key: 'dest', icon: mdiMapSearchOutline, cap: 'Destination', label: destLabel.value },
+  { key: 'type', icon: mdiBagPersonalOutline, cap: 'Type de voyage', label: typeLabel.value },
+  { key: 'per', icon: mdiCalendarMonthOutline, cap: 'Période', label: perLabel.value },
+])
+
+const sheetTitle = computed(() => ({ dest: 'Destination', type: 'Type de voyage', per: 'Période' }[sheet.value] || ''))
+
+// Sanity visual-editing (stega) injects invisible chars into string fields in
+// dev — strip them when comparing a region name against a literal. No-op in prod.
+const clean = s => (s || '').replace(/[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]|[\u{E0000}-\u{E007F}]/gu, '')
+
+// --- region ordering / scope ---
+const orderedRegions = computed(() => {
+  return [...props.regions].sort((a, b) => {
+    const ia = REGION_ORDER.indexOf(clean(a.nom))
+    const ib = REGION_ORDER.indexOf(clean(b.nom))
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib) || clean(a.nom).localeCompare(clean(b.nom))
+  })
+})
+
+const scopeButtons = computed(() => {
+  const noms = orderedRegions.value.map(r => r.nom)
+  const france = noms.find(n => clean(n) === 'France')
+  const rest = noms.filter(n => clean(n) !== 'France')
+  return ['Toutes', ...(france ? [france] : []), 'Hors France', ...rest]
+})
+
+function visibleRegionNoms() {
+  const all = orderedRegions.value.map(r => r.nom)
+  if (scope.value === 'Toutes') return all
+  if (scope.value === 'Hors France') return all.filter(n => clean(n) !== 'France')
+  return [scope.value]
+}
+
+const destinationsByRegion = computed(() =>
+  visibleRegionNoms().map(nom => ({
+    nom,
+    destinations: props.destinations
+      .filter(d => d.regions?.some(r => r.nom === nom))
+      .sort((a, b) => a.title.localeCompare(b.title)),
+  })).filter(g => g.destinations.length > 0),
+)
+
+const mobileDests = computed(() =>
+  destinationsByRegion.value.flatMap(g => g.destinations.map(d => ({ ...d, regionNom: g.nom }))),
+)
+
+// --- segment labels ---
+const destLabel = computed(() => {
+  const n = selDest.value.length
+  if (n === 0) return 'Toutes destinations'
+  if (n === 1) return destSlugLabel(selDest.value[0])
+  return `${n} destinations`
+})
+const typeLabel = computed(() => {
+  const n = (selType.value ? 1 : 0) + selActivities.value.length
+  return n === 0 ? 'Type de voyage' : `${n} critère${n > 1 ? 's' : ''}`
+})
+const perLabel = computed(() => {
+  const n = selMonths.value.length
+  if (n === 0) return 'Toute période'
+  if (n === 12) return "Toute l'année"
+  return `${n} mois`
+})
+
+function destSlugLabel(slug) {
+  if (slug === 'top-destination') return 'Top destinations'
+  const r = props.regions.find(x => x.slug === slug)
+  if (r) return r.nom
+  const d = props.destinations.find(x => x.slug === slug)
+  return d ? d.title : slug
+}
+
+function regionColor(nom) {
+  return REGION_COLOR[nom] || '#2B4C52'
+}
+
+function thumbBg(d) {
+  const assetRef = d.image?.asset?._ref
+  if (assetRef) {
+    const url = getImageUrl(assetRef, null, null, 400)
+    if (url) return `background-image:url('${url}')`
+  }
+  return 'background:linear-gradient(135deg,#3d5f7a,#7aa0c0)'
+}
+
+// --- query mutation (route is the single source of truth) ---
+function updateQuery(patch) {
+  const q = { ...route.query }
+  Object.entries(patch).forEach(([k, v]) => {
+    const empty = v === undefined || v === null || v === '' || (Array.isArray(v) && v.length === 0)
+    if (empty) delete q[k]
+    else q[k] = Array.isArray(v) ? v.join(',') : v
+  })
+  router.replace({ path: route.path, query: Object.keys(q).length ? q : undefined })
+}
+
+function toggleDest(slug) {
+  const arr = [...selDest.value]
+  const i = arr.indexOf(slug)
+  if (i === -1) arr.push(slug)
+  else arr.splice(i, 1)
+  updateQuery({ destination: arr })
+}
+function setType(val) {
+  updateQuery({ travelType: selType.value === val ? '' : val })
+}
+function toggleActivity(slug) {
+  const arr = [...selActivities.value]
+  const i = arr.indexOf(slug)
+  if (i === -1) arr.push(slug)
+  else arr.splice(i, 1)
+  updateQuery({ activities: arr })
+}
+function setSeason(name) {
+  if (isSeasonOn(name)) updateQuery({ from: '' })
+  else updateQuery({ from: (SEASONS[name] || []).map(String) })
+}
+function clearSeason() {
+  updateQuery({ from: '' })
+}
+function toggleMonth(m) {
+  const arr = [...selMonths.value]
+  const i = arr.indexOf(m)
+  if (i === -1) arr.push(m)
+  else arr.splice(i, 1)
+  updateQuery({ from: arr.map(String) })
+}
+function isSeasonOn(name) {
+  const s = SEASONS[name]
+  return s.length === selMonths.value.length && s.every(m => selMonths.value.includes(m))
+}
+
+function clearPanel(seg) {
+  if (seg === 'dest') {
+    updateQuery({ destination: [] })
+    scope.value = 'Toutes'
+  }
+  else if (seg === 'type') updateQuery({ travelType: '', activities: [] })
+  else updateQuery({ from: '' })
+}
+
+function toggleSegment(seg) {
+  openSegment.value = openSegment.value === seg ? null : seg
+}
+</script>
+
+<style scoped>
+.selector {
+  --teal: #2B4C52;
+  --or: #DE5E2C;
+  --gt: #E7EEED;
+  --t1: #222223;
+  --t2: #5d6566;
+  --t3: #9aa0a1;
+  --bd1: rgba(43, 76, 82, .12);
+  --bd2: rgba(43, 76, 82, .24);
+  --rmd: 9px;
+  --rlg: 14px;
+}
+
+/* ---------- Desktop bar ---------- */
+.bar {
+  display: flex;
+  background: #fff;
+  border: 1px solid var(--bd2);
+  border-radius: var(--rlg);
+  overflow: hidden;
+}
+.seg {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 16px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  text-align: left;
+  border-right: 1px solid var(--bd1);
+}
+.seg:last-child { border-right: none; }
+.seg.on { background: var(--gt); }
+.seg .lead-i { font-size: 19px; color: var(--teal); }
+.seg-txt { display: flex; flex-direction: column; }
+.c { font-size: 11px; color: var(--t3); display: block; margin-bottom: 1px; }
+.v { font-weight: 600; font-size: 14px; color: var(--t1); }
+.chev { margin-left: auto; font-size: 18px; color: var(--teal); }
+
+.panel {
+  background: #fff;
+  border: 1px solid var(--bd2);
+  border-top: none;
+  border-radius: 0 0 var(--rlg) var(--rlg);
+  padding: 18px;
+  transform-origin: top center;
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+.panel-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin: -2px -8px 0;
+  padding: 2px 8px 0;
+}
+
+/* Dropdown open/close animation */
+.panel-enter-active,
+.panel-leave-active {
+  transition: opacity .22s ease, transform .22s ease;
+  overflow: hidden;
+}
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(-8px) scaleY(.98);
+}
+@media (prefers-reduced-motion: reduce) {
+  .panel-enter-active,
+  .panel-leave-active {
+    transition: none;
+  }
+}
+
+.quick { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.qbtn {
+  padding: 9px 15px;
+  border: 1px solid var(--bd1);
+  border-radius: 30px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--t1);
+  cursor: pointer;
+  font-family: inherit;
+}
+.qbtn.on { border-color: var(--teal); background: var(--teal); color: #fff; }
+
+.affine { font-size: 13px; font-weight: 600; margin: 0 0 6px; color: var(--t1); }
+.reg {
+  font-size: 11px;
+  color: var(--t3);
+  margin: 14px 0 8px;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+.thumb {
+  position: relative;
+  height: 118px;
+  border-radius: var(--rlg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 2px solid transparent;
+  padding: 0;
+  background: none;
+}
+.thumb.on { border-color: var(--or); }
+.ph {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+}
+.ph .v-icon { font-size: 34px; color: rgba(255, 255, 255, .3); }
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(20, 30, 28, .74), rgba(20, 30, 28, .06) 60%);
+}
+.name {
+  position: absolute;
+  left: 11px;
+  bottom: 9px;
+  right: 11px;
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  text-align: left;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, .45);
+}
+.badge {
+  position: absolute;
+  top: 9px;
+  right: 9px;
+  background: rgba(255, 255, 255, .96);
+  color: var(--teal);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 20px;
+}
+.chk {
+  position: absolute;
+  top: 9px;
+  left: 9px;
+  width: 23px;
+  height: 23px;
+  border-radius: 50%;
+  background: var(--or);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cgrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  gap: 8px;
+}
+.cgrid.months { grid-template-columns: repeat(auto-fit, minmax(76px, 1fr)); }
+.citem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border: 1px solid var(--bd1);
+  border-radius: var(--rmd);
+  background: #fff;
+  font-size: 13px;
+  color: var(--t1);
+  cursor: pointer;
+  font-family: inherit;
+}
+.citem.center { justify-content: center; }
+.citem.on { border-color: var(--teal); background: var(--gt); color: var(--teal); }
+
+.foot {
+  display: flex;
+  align-items: center;
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid var(--bd1);
+}
+.clear {
+  background: none;
+  border: none;
+  font-size: 13px;
+  color: var(--t2);
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: inherit;
+}
+.go {
+  margin-left: auto;
+  background: var(--or);
+  color: #fff;
+  border: none;
+  padding: 12px 26px;
+  border-radius: 30px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+.go:hover { filter: brightness(.95); }
+
+/* ---------- Mobile ---------- */
+.prow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--bd1);
+  border-radius: var(--rmd);
+  background: #fff;
+  margin-bottom: 10px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+.prow .lead-i { font-size: 20px; color: var(--teal); }
+.prow .chev { margin-left: auto; color: var(--teal); }
+
+.sheet {
+  background: #fff;
+  border-radius: 18px 18px 0 0;
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+  overflow: hidden;
+}
+.handle {
+  width: 38px;
+  height: 4px;
+  border-radius: 3px;
+  background: var(--bd2);
+  margin: 2px auto 12px;
+}
+.sheet h5 { font-size: 15px; font-weight: 600; margin: 0 0 12px; color: var(--t1); }
+.schips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  overflow-y: auto;
+}
+.sdiv { width: 100%; height: 1px; background: var(--bd1); margin: 4px 0; }
+.schip {
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--bd1);
+  background: #fff;
+  color: var(--t1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+}
+.schip.on { border-color: var(--teal); background: var(--gt); color: var(--teal); }
+.schip.scope { border-color: var(--teal); background: var(--teal); color: #fff; }
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.sheet .go { margin: 16px 0 0; width: 100%; text-align: center; }
+</style>

--- a/app/components/content/search/VoyageSelectorBar.vue
+++ b/app/components/content/search/VoyageSelectorBar.vue
@@ -469,7 +469,7 @@ function destSlugLabel(slug) {
 }
 
 function regionColor(nom) {
-  return REGION_COLOR[nom] || '#2B4C52'
+  return REGION_COLOR[clean(nom)] || '#2B4C52'
 }
 
 function thumbBg(d) {
@@ -782,6 +782,18 @@ function toggleSegment(seg) {
 .prow .chev { margin-left: auto; color: var(--teal); }
 
 .sheet {
+  /* Vuetify teleports the bottom-sheet out of .selector, so the CSS vars
+     must be re-declared here for borders / backgrounds to resolve. */
+  --teal: #2B4C52;
+  --or: #DE5E2C;
+  --gt: #E7EEED;
+  --t1: #222223;
+  --t2: #5d6566;
+  --t3: #9aa0a1;
+  --bd1: rgba(43, 76, 82, .12);
+  --bd2: rgba(43, 76, 82, .24);
+  --rmd: 9px;
+  --rlg: 14px;
   background: #fff;
   border-radius: 18px 18px 0 0;
   padding: 14px 16px 16px;
@@ -801,7 +813,10 @@ function toggleSegment(seg) {
 .schips {
   display: flex;
   flex-wrap: wrap;
+  align-content: flex-start;
   gap: 7px;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
 }
 .sdiv { width: 100%; height: 1px; background: var(--bd1); margin: 4px 0; }
@@ -821,5 +836,5 @@ function toggleSegment(seg) {
 .schip.on { border-color: var(--teal); background: var(--gt); color: var(--teal); }
 .schip.scope { border-color: var(--teal); background: var(--teal); color: #fff; }
 .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
-.sheet .go { margin: 16px 0 0; width: 100%; text-align: center; }
+.sheet .go { margin: 16px 0 0; width: 100%; text-align: center; flex: 0 0 auto; }
 </style>

--- a/app/composables/useVoyageFilters.js
+++ b/app/composables/useVoyageFilters.js
@@ -1,0 +1,109 @@
+import { getDateStatus } from '~/utils/getDateStatus'
+
+// Month number (1-12) -> Sanity monthlyAvailability key
+const MONTH_KEYS = [
+  '', // 0 unused
+  'janvier', 'fevrier', 'mars', 'avril', 'mai', 'juin',
+  'juillet', 'aout', 'septembre', 'octobre', 'novembre', 'decembre',
+]
+
+// Resolve a list of destination param slugs (which may be destination slugs,
+// region slugs or the `top-destination` pseudo-slug) into the set of
+// destination titles they cover.
+function resolveDestinationTitles(destSlugs, { destinations = [], regions = [] }) {
+  const titles = new Set()
+  destSlugs.forEach((slug) => {
+    if (slug === 'top-destination') {
+      destinations.filter(d => d.isTopDestination).forEach(d => titles.add(d.title))
+      return
+    }
+    const region = regions.find(r => r.slug === slug)
+    if (region) {
+      destinations
+        .filter(d => d.regions?.some(r => r.nom === region.nom))
+        .forEach(d => titles.add(d.title))
+      return
+    }
+    const dest = destinations.find(d => d.slug === slug)
+    if (dest) titles.add(dest.title)
+  })
+  return titles
+}
+
+export function useVoyageFilters() {
+  function filterByDestinations(voyages, destSlugs, ctx = {}) {
+    if (!destSlugs || destSlugs.length === 0) return voyages
+    const titles = resolveDestinationTitles(destSlugs, ctx)
+    if (titles.size === 0) return voyages
+    return voyages.filter(v => v.destinations?.some(d => titles.has(d.title)))
+  }
+
+  function filterByType(voyages, travelTypeLabel, travelTypes = {}) {
+    if (!travelTypeLabel) return voyages
+    const typeFilters = {
+      [travelTypes.group]: v => v.availabilityTypes?.includes('groupe'),
+      [travelTypes.individual]: v => v.availabilityTypes?.includes('privatisation'),
+    }
+    const fn = typeFilters[travelTypeLabel]
+    return fn ? voyages.filter(fn) : voyages
+  }
+
+  function filterByDate(voyages, fromList) {
+    if (!fromList) return voyages
+    const monthNumbers = fromList.split(',').map(Number).filter(n => n > 0 && n <= 12)
+    if (monthNumbers.length === 0) return voyages
+    const selectedKeys = monthNumbers.map(n => MONTH_KEYS[n])
+
+    return voyages.filter((v) => {
+      const avail = v.monthlyAvailability
+      if (!Array.isArray(avail)) return false
+      const cleaned = avail.map(m => m.replace(/[\u200B-\u200F\uFEFF]/g, ''))
+      return selectedKeys.some(key => cleaned.includes(key))
+    })
+  }
+
+  function filterByCategories(voyages, categorySlugs) {
+    if (!categorySlugs || categorySlugs.length === 0) return voyages
+    return voyages.filter(v => v.categories?.some(c => categorySlugs.includes(c.slug)))
+  }
+
+  function filterByConfirmed(voyages, confirmedFilter, travelsWithDates) {
+    if (!confirmedFilter) return voyages
+    if (!Array.isArray(travelsWithDates) || travelsWithDates.length === 0) return voyages
+
+    const confirmedSlugs = new Set()
+    travelsWithDates.forEach((travel) => {
+      if (!Array.isArray(travel.dates)) return
+      const hasConfirmed = travel.dates.some(date => getDateStatus(date)?.status === 'confirmed')
+      if (hasConfirmed) confirmedSlugs.add(travel.slug)
+    })
+    return voyages.filter(v => confirmedSlugs.has(v.slug))
+  }
+
+  // Compose every filter from a normalized filter object.
+  // filters: { destinations: string[], travelType: string, from: string,
+  //            activities: string[], confirmed: boolean }
+  function applyFilters(voyages, filters = {}, ctx = {}) {
+    let list = voyages || []
+    list = filterByDestinations(list, filters.destinations, ctx)
+    list = filterByType(list, filters.travelType, ctx.travelTypes)
+    list = filterByDate(list, filters.from)
+    list = filterByCategories(list, filters.activities)
+    list = filterByConfirmed(list, filters.confirmed, ctx.travelsByDate)
+    return list
+  }
+
+  function countMatching(voyages, filters = {}, ctx = {}) {
+    return applyFilters(voyages, filters, ctx).length
+  }
+
+  return {
+    filterByDestinations,
+    filterByType,
+    filterByDate,
+    filterByCategories,
+    filterByConfirmed,
+    applyFilters,
+    countMatching,
+  }
+}

--- a/app/pages/voyages/index.vue
+++ b/app/pages/voyages/index.vue
@@ -6,7 +6,7 @@
           Accueil
         </NuxtLink> › Voyages
       </p>
-      <h1 class="h1">
+      <h1 class="h1 text-primary">
         {{ pageTitle }}
       </h1>
       <p class="lead">

--- a/app/pages/voyages/index.vue
+++ b/app/pages/voyages/index.vue
@@ -1,95 +1,74 @@
 <template>
-  <v-container
-    class="py-0 my-0 px-2 px-md-4"
-    fluid
-  >
-    <SearchHeroSection
-      :destination="fetchedDestination"
-      :page-content="searchContent"
-    >
-      <SearchField />
-    </SearchHeroSection>
-    <v-row class=" pb-0 pt-4 mt-md-12">
-      <v-col
-        cols="12"
-        class="px-4 px-md-12 d-flex ga-2 align-center flex-wrap"
-      >
-        <span class="text-primary text-h3 font-weight-bold mr-2 mr-md-5">{{ nbVoyages <= 1 ? `${nbVoyages} ${searchContent?.oneTrip || 'voyage'}` : `${nbVoyages}
-            ${searchContent?.multipleTrips || 'voyages'}` }}
+  <div class="voyages-search">
+    <v-container class="max-container-width py-6 py-md-8">
+      <p class="crumb">
+        <NuxtLink to="/">
+          Accueil
+        </NuxtLink> › Voyages
+      </p>
+      <h1 class="h1">
+        {{ pageTitle }}
+      </h1>
+      <p class="lead">
+        {{ leadText }}
+      </p>
+
+      <ClientOnly>
+        <VoyageSelectorBar
+          :destinations="destinationsWithCount"
+          :regions="regions || []"
+          :categories="categoriesWithCount"
+          :travel-types="travelTypesNormalized"
+          :all-voyages="allVoyages || []"
+        />
+        <template #fallback>
+          <div class="selector-skeleton" />
+        </template>
+      </ClientOnly>
+
+      <!-- Results bar -->
+      <div class="resbar">
+        <span class="n">
+          {{ nbVoyages }} {{ nbVoyages <= 1 ? (searchContent?.oneTrip || 'voyage') : (searchContent?.multipleTrips || 'voyages') }}
         </span>
-
-        <div class="d-flex align-center flex-wrap ga-2">
-          <!-- Add closable props & logic -->
-          <v-chip
-            v-if="routeQuery.destination"
-            variant="flat"
-            :size="lgAndUp ? 'x-large' : 'large'"
-            color="secondary-light-2"
-            density="comfortable"
-          >
-            <span class="d-flex align-center text-white text-caption text-sm-subtitle-1 px-sm-3 pb-1">
-              {{ capitalizeFirstLetter(routeQuery.destination) }}
-            </span>
-          </v-chip>
-          <!-- Add closable props & logic -->
-
-          <v-chip
-            v-if="routeQuery.travelType"
-            variant="flat"
-            :size="lgAndUp ? 'x-large' : 'large'"
-            color="secondary-light-2"
-            density="comfortable"
-            @click:close="chip = false"
-          >
-            <span class="d-flex align-center text-white text-caption text-sm-subtitle-1 px-3 pb-1">
-              {{ routeQuery.travelType }}
-            </span>
-          </v-chip>
-          <!-- Add closable props & logic -->
-
-          <v-chip
-            v-if="routeQuery.from"
-            variant="flat"
-            :size="lgAndUp ? 'x-large' : 'large'"
-            color="secondary-light-2"
-            density="comfortable"
-          >
-            <span class="d-flex align-center text-white text-caption text-sm-subtitle-1 px-3 pb-1">
-              {{ parsedDates }}
-            </span>
-          </v-chip>
-        </div>
+        <span
+          v-for="chip in activeChips"
+          :key="chip.type + chip.value"
+          class="tag"
+        >
+          {{ chip.label }}
+          <v-icon
+            :icon="mdiClose"
+            size="13"
+            @click="removeChip(chip)"
+          />
+        </span>
         <v-spacer />
-        <div class="d-flex justify-end ml-auto align-center ga-3 flex-wrap">
-          <v-checkbox
-            v-model="confirmedOnly"
-            hide-details
-            color="primary"
-            density="compact"
-            label="Voir tous les départs garantis"
-            content-class="text-subtitle-2 text-sm-body-1"
-          >
-            <template #label>
-              <span class="text-subtitle-2 text-sm-body-1">
-                Voir tous les départs garantis
-              </span>
-            </template>
-          </v-checkbox>
-          <v-btn
-            color="primary"
-            variant="outlined"
-            size="large"
-            class="text-subtitle-2 text-sm-body-1 reset-btn-size"
+        <v-checkbox
+          v-model="confirmedOnly"
+          hide-details
+          color="primary"
+          density="compact"
+          class="garanti-check"
+        >
+          <template #label>
+            <span class="text-subtitle-2">Départs garantis</span>
+          </template>
+        </v-checkbox>
+        <v-btn
+          color="primary"
+          variant="outlined"
+          size="small"
+          class="reset-btn"
+          @click="reinitiliazeFilter"
+        >
+          {{ searchContent?.resetButton || 'Réinitialiser' }}
+        </v-btn>
+      </div>
+    </v-container>
 
-            @click="reinitiliazeFilter"
-          >
-            {{ searchContent?.resetButton || 'Réinitialiser' }}
-          </v-btn>
-        </div>
-      </v-col>
-    </v-row>
     <v-container
-      class=" py-0 px-0 px-md-8 mt-3"
+      class="py-0 px-0 px-md-8 mt-2 max-container-width"
       fluid
     >
       <DisplayVoyagesRow
@@ -99,55 +78,29 @@
         :item-list-name="searchListName"
       />
     </v-container>
-  </v-container>
+  </div>
 </template>
 
 <script setup>
-import { useDisplay } from 'vuetify'
+import { mdiClose } from '@mdi/js'
 import _ from 'lodash'
-import SearchField from '~/components/content/SearchField.vue'
-import { getDateStatus } from '~/utils/getDateStatus'
+import { useVoyageFilters } from '~/composables/useVoyageFilters'
 
-const { lgAndUp } = useDisplay()
 const { trackSearchBar, trackViewItemList } = useGtmTracking()
 const { formatVoyagesForGtm } = useGtmVoyageFormatter()
+const { applyFilters } = useVoyageFilters()
 
 useSeoMeta({
-  htmlAttrs: {
-    lang: 'fr',
-  },
+  htmlAttrs: { lang: 'fr' },
   robots: 'noindex, follow',
   canonical: 'https://www.odysway.com/voyages',
 })
+
 const router = useRouter()
 const route = useRoute()
-const routeQuery = computed(() => route.query)
 const confirmedOnly = ref(route.query.confirmed === 'true')
 
-const searchContentQuery = groq`*[_type == "search"][0]{
-  oneTrip,
-  multipleTrips,
-  resetButton,
-  image,
-  searchHero
-}`
-
-const { data: searchContent } = await useSanityQuery(searchContentQuery)
-
-const fetchedDestinationQuery = groq`*[_type == "destination" && slug.current == $slug][0]{
-  title,
-  interjection,
-  image
-}`
-const fetchedDestinationSlug = computed(() => route.query.destination || '')
-const { data: fetchedDestination } = useSanityQuery(
-  fetchedDestinationQuery,
-  { slug: fetchedDestinationSlug },
-)
-
-const capitalizeFirstLetter = (str) => {
-  return str.charAt(0).toUpperCase() + str.slice(1)
-}
+const leadText = 'Choisissez une destination, un type de voyage et une période : la liste se met à jour en direct. Tous nos séjours se vivent en petit groupe ou en privatisé, au plus près des habitants.'
 
 const monthNumberToFrench = [
   '', // 0 index unused
@@ -155,70 +108,22 @@ const monthNumberToFrench = [
   'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre',
 ]
 
-const parsedDates = computed(() => {
-  if (!routeQuery.value.from) return ''
-  const monthNumbers = routeQuery.value.from.split(',').map(Number).filter(n => n > 0 && n <= 12)
-  if (monthNumbers.length === 0) return ''
-  const monthNames = monthNumbers.map(n => monthNumberToFrench[n])
-  return monthNames.join(' - ')
-})
-
-function filterByDestination(voyages, destination) {
-  if (!destination) return voyages
-  return voyages.filter(v => v.destinations?.some(d => d.title.includes(destination)))
-}
-
-const travelTypesQuery = groq`*[_type == "search"][0]{
+// ---------- Sanity data ----------
+const searchContentQuery = groq`*[_type == "search"][0]{
+  oneTrip,
+  multipleTrips,
+  resetButton,
+  image,
+  searchHero,
   travelTypes
 }`
-
-const { data: travelTypes } = await useSanityQuery(travelTypesQuery)
-const TRAVEL_TYPES = {
-  GROUP: travelTypes.value?.travelTypes?.group,
-  INDIVIDUAL: travelTypes.value?.travelTypes?.individual,
-}
-
-function filterByType(voyages, travelType) {
-  // Early return for falsy values
-  if (!travelType) return voyages
-
-  const typeFilters = {
-    [TRAVEL_TYPES.GROUP]: voyage => voyage.availabilityTypes?.includes('groupe'),
-    [TRAVEL_TYPES.INDIVIDUAL]: voyage => voyage.availabilityTypes?.includes('privatisation'),
-  }
-
-  const filterFn = typeFilters[travelType]
-  return filterFn ? voyages.filter(filterFn) : voyages
-}
-
-function filterByDate(voyages, fromList) {
-  if (!fromList) return voyages
-  const monthNumbers = fromList.split(',').map(Number).filter(n => n > 0 && n <= 12)
-  if (monthNumbers.length === 0) return voyages
-
-  // Map month numbers to keys used in the object
-  const monthKeys = [
-    '', // 0 index unused
-    'janvier', 'fevrier', 'mars', 'avril', 'mai', 'juin',
-    'juillet', 'aout', 'septembre', 'octobre', 'novembre', 'decembre',
-  ]
-  const selectedKeys = monthNumbers.map(n => monthKeys[n])
-
-  return voyages.filter((v) => {
-    const avail = v.monthlyAvailability
-    if (!Array.isArray(avail)) return false
-    // Clean the month strings by removing any invisible characters
-    const cleanedAvail = avail.map(month => month.replace(/[\u200B-\u200F\uFEFF]/g, ''))
-    return selectedKeys.some(key => cleanedAvail.includes(key))
-  })
-}
+const { data: searchContent } = await useSanityQuery(searchContentQuery)
 
 const regionsQuery = groq`*[_type == "region"]{
   _id,
   nom,
   "slug": slug.current
 }`
-
 const { data: regions } = await useSanityQuery(regionsQuery)
 
 const destinationsQuery = groq`*[_type == "destination"]{
@@ -226,12 +131,19 @@ const destinationsQuery = groq`*[_type == "destination"]{
   title,
   "slug": slug.current,
   isTopDestination,
+  image,
   regions[]-> {
     nom
   }
 }`
-
 const { data: destinations } = await useSanityQuery(destinationsQuery)
+
+const categoriesQuery = groq`*[_type == "category"]{
+  _id,
+  title,
+  "slug": slug.current
+}`
+const { data: categories } = await useSanityQuery(categoriesQuery)
 
 const { data: travelsByDate } = await useAsyncData('travels-by-date', () =>
   $fetch('/api/v1/booking/travels-by-date'),
@@ -264,163 +176,170 @@ const voyagesQuery = groq`*[
   },
   categories[]->{
     _id,
-    title
+    title,
+    "slug": slug.current
   }
 }`
-
 const { data: allVoyages } = await useSanityQuery(voyagesQuery)
 
-const voyages = computed(() => {
-  let list = allVoyages.value || []
-  let destination = null
-  let regionSlug = null
-  let isRegionSearch = false
-  let isTopDestinations = false
+// ---------- Normalized travel types ----------
+const travelTypesNormalized = computed(() => ({
+  group: searchContent.value?.travelTypes?.group,
+  individual: searchContent.value?.travelTypes?.individual,
+}))
 
-  if (route.query.destination) {
-    const region = regions.value?.find(r => r.slug === route.query.destination)
-    if (region) {
-      isRegionSearch = true
-      regionSlug = region.slug
-    }
-    else if (route.query.destination === 'top-destination') {
-      isRegionSearch = true
-      isTopDestinations = true
-    }
-    else {
-      const found = destinations.value?.find(d => d.slug === route.query.destination)
-      if (found) destination = found.title
-    }
-  }
-
-  const travelType = route.query.travelType || null
-  const fromList = route.query.from || null
-
-  if (isRegionSearch) {
-    let destinationList = []
-    if (isTopDestinations) {
-      destinationList = (destinations.value || []).filter(d => d.isTopDestination)
-    }
-    else {
-      const region = regions.value?.find(r => r.slug === regionSlug)
-      if (region) {
-        destinationList = (destinations.value || []).filter(dest =>
-          dest.regions && dest.regions.some(r => r.nom === region.nom),
-        )
+// ---------- Counts for the selector ----------
+const destinationsWithCount = computed(() => {
+  const counts = {}
+  ;(allVoyages.value || []).forEach((v) => {
+    const seen = new Set()
+    v.destinations?.forEach((d) => {
+      if (!seen.has(d.title)) {
+        seen.add(d.title)
+        counts[d.title] = (counts[d.title] || 0) + 1
       }
-    }
-    const destinationNames = destinationList.map(d => d.title)
-    list = list.filter(v =>
-      v.destinations?.some(d => destinationNames.includes(d.title)),
-    )
-  }
-  else {
-    list = filterByDestination(list, destination)
-  }
+    })
+  })
+  return (destinations.value || [])
+    .map(d => ({ ...d, count: counts[d.title] || 0 }))
+    .filter(d => d.count > 0)
+})
 
-  list = filterByType(list, travelType)
-  list = filterByDate(list, fromList)
+const categoriesWithCount = computed(() => {
+  const counts = {}
+  ;(allVoyages.value || []).forEach((v) => {
+    v.categories?.forEach((c) => {
+      if (c.slug) counts[c.slug] = (counts[c.slug] || 0) + 1
+    })
+  })
+  return (categories.value || [])
+    .map(c => ({ ...c, count: counts[c.slug] || 0 }))
+    .filter(c => c.count > 0)
+    .sort((a, b) => b.count - a.count)
+})
 
+// ---------- Selections derived from route.query ----------
+const selDest = computed(() => (route.query.destination ? String(route.query.destination).split(',').filter(Boolean) : []))
+const selActivities = computed(() => (route.query.activities ? String(route.query.activities).split(',').filter(Boolean) : []))
+const selMonths = computed(() => (route.query.from ? String(route.query.from).split(',').map(Number).filter(n => n > 0 && n <= 12) : []))
+
+const pageTitle = computed(() => searchContent.value?.searchHero?.defaultTitle || 'Nos voyages en immersion')
+
+const parsedDates = computed(() => {
+  if (!route.query.from) return ''
+  const names = selMonths.value.map(n => monthNumberToFrench[n])
+  return names.join(' - ')
+})
+
+// ---------- Filtering (shared with the selector via useVoyageFilters) ----------
+const filterCtx = computed(() => ({
+  destinations: destinations.value || [],
+  regions: regions.value || [],
+  travelTypes: travelTypesNormalized.value,
+  travelsByDate: travelsByDate.value || [],
+}))
+
+const filteredVoyages = computed(() => {
+  const list = applyFilters(allVoyages.value || [], {
+    destinations: selDest.value,
+    travelType: route.query.travelType || '',
+    from: route.query.from || '',
+    activities: selActivities.value,
+    confirmed: confirmedOnly.value,
+  }, filterCtx.value)
   return _.uniqBy(list, 'slug')
 })
 
-function filterByConfirmed(voyages, confirmedFilter, travelsWithDates) {
-  if (!confirmedFilter) return voyages
-  if (!Array.isArray(travelsWithDates) || travelsWithDates.length === 0) return voyages
+const nbVoyages = computed(() => filteredVoyages.value?.length || 0)
 
-  const confirmedSlugs = new Set()
-
-  travelsWithDates.forEach((travel) => {
-    if (!Array.isArray(travel.dates)) return
-    const hasConfirmedDate = travel.dates.some((date) => {
-      const status = getDateStatus(date)
-      return status?.status === 'confirmed'
-    })
-    if (hasConfirmedDate) confirmedSlugs.add(travel.slug)
-  })
-
-  return voyages.filter(v => confirmedSlugs.has(v.slug))
+// ---------- Labels ----------
+function destLabel(slug) {
+  if (slug === 'top-destination') return 'Top destinations'
+  const r = (regions.value || []).find(x => x.slug === slug)
+  if (r) return r.nom
+  const d = (destinations.value || []).find(x => x.slug === slug)
+  return d ? d.title : slug
+}
+function categoryLabel(slug) {
+  const c = (categories.value || []).find(x => x.slug === slug)
+  return c ? c.title.trim() : slug
+}
+function monthsLabel() {
+  const n = selMonths.value.length
+  if (n === 12) return "Toute l'année"
+  if (n > 3) return `${n} mois`
+  return [...selMonths.value].sort((a, b) => a - b).map(m => monthNumberToFrench[m]).join(' - ')
 }
 
-const filteredVoyages = computed(() => {
-  const baseVoyages = voyages.value || []
-  return filterByConfirmed(baseVoyages, confirmedOnly.value, travelsByDate.value || [])
+// ---------- Removable result chips ----------
+const activeChips = computed(() => {
+  const chips = []
+  selDest.value.forEach(slug => chips.push({ type: 'dest', value: slug, label: destLabel(slug) }))
+  if (route.query.travelType) chips.push({ type: 'type', value: route.query.travelType, label: route.query.travelType })
+  selActivities.value.forEach(slug => chips.push({ type: 'activity', value: slug, label: categoryLabel(slug) }))
+  if (selMonths.value.length) chips.push({ type: 'months', value: 'months', label: monthsLabel() })
+  return chips
 })
 
-const nbVoyages = computed(() => {
-  return filteredVoyages.value?.length || 0
-})
-
-// GTM: Track search_bar when filters are applied (checkbox or route changes)
-watch([confirmedOnly], () => {
-  // Get the destination title if available
-  let destinationTitle = null
-  if (route.query.destination) {
-    const dest = destinations.value?.find(d => d.slug === route.query.destination)
-    if (dest) {
-      destinationTitle = dest.title
-    }
-    else {
-      const region = regions.value?.find(r => r.slug === route.query.destination)
-      if (region) {
-        destinationTitle = region.nom
-      }
-      else {
-        destinationTitle = capitalizeFirstLetter(route.query.destination)
-      }
-    }
+function removeChip(chip) {
+  const q = { ...route.query }
+  if (chip.type === 'dest') {
+    const arr = selDest.value.filter(s => s !== chip.value)
+    if (arr.length) q.destination = arr.join(',')
+    else delete q.destination
   }
-
-  // Format period as comma-separated month names
-  let periodeFormatted = null
-  if (route.query.from) {
-    const monthNumbers = route.query.from.split(',').map(Number).filter(n => n > 0 && n <= 12)
-    if (monthNumbers.length > 0) {
-      periodeFormatted = monthNumbers.map(n => monthNumberToFrench[n]).join(', ')
-    }
+  else if (chip.type === 'type') {
+    delete q.travelType
   }
+  else if (chip.type === 'activity') {
+    const arr = selActivities.value.filter(s => s !== chip.value)
+    if (arr.length) q.activities = arr.join(',')
+    else delete q.activities
+  }
+  else if (chip.type === 'months') {
+    delete q.from
+  }
+  router.push({ path: route.path, query: Object.keys(q).length ? q : undefined })
+}
 
+// ---------- GTM: search_bar on any filter change ----------
+function fireSearchBarTracking() {
+  const destinationTitle = selDest.value.length ? selDest.value.map(destLabel).join(', ') : null
+  const periodeFormatted = selMonths.value.length
+    ? selMonths.value.map(n => monthNumberToFrench[n]).join(', ')
+    : null
   trackSearchBar({
     destination: destinationTitle,
     typeVoyage: route.query.travelType || null,
     periode: periodeFormatted,
     voyageGaranti: confirmedOnly.value,
   })
-}, { deep: true })
+}
 
-// GTM: Build dynamic list name based on search filters
+watch(
+  () => [route.query.destination, route.query.travelType, route.query.from, route.query.activities, confirmedOnly.value].join('|'),
+  () => fireSearchBarTracking(),
+)
+
+// ---------- GTM: dynamic list name ----------
 const searchListName = computed(() => {
-  let listName = 'Search Results'
-  if (route.query.destination) {
-    listName += ` - ${capitalizeFirstLetter(route.query.destination)}`
-  }
-  if (route.query.travelType) {
-    listName += ` - ${route.query.travelType}`
-  }
-  if (route.query.from) {
-    listName += ` - ${parsedDates.value}`
-  }
-  if (confirmedOnly.value) {
-    listName += ' - Départs garantis'
-  }
-  return listName
+  let name = 'Search Results'
+  if (selDest.value.length) name += ` - ${selDest.value.map(destLabel).join(', ')}`
+  if (route.query.travelType) name += ` - ${route.query.travelType}`
+  if (route.query.from) name += ` - ${parsedDates.value}`
+  if (selActivities.value.length) name += ` - ${selActivities.value.map(categoryLabel).join(', ')}`
+  if (confirmedOnly.value) name += ' - Départs garantis'
+  return name
 })
 
-// GTM: Track view_item_list when results are displayed
-// Store the last tracked voyage IDs to prevent duplicate tracking
+// ---------- GTM: view_item_list when results change ----------
 const lastTrackedVoyageIds = ref(null)
-
 watch(filteredVoyages, (newVoyages) => {
   if (newVoyages && newVoyages.length > 0) {
-    // Create a sorted string of voyage IDs to compare
     const newVoyageIds = newVoyages.map(v => v._id).sort().join(',')
-
-    // Only track if the voyage list actually changed
     if (newVoyageIds !== lastTrackedVoyageIds.value) {
       lastTrackedVoyageIds.value = newVoyageIds
-
       const formattedVoyages = formatVoyagesForGtm(newVoyages)
-
       if (formattedVoyages && formattedVoyages.length > 0) {
         trackViewItemList({
           currency: 'EUR',
@@ -431,29 +350,17 @@ watch(filteredVoyages, (newVoyages) => {
     }
   }
 }, { immediate: true })
-function reinitiliazeFilter() {
-  // GTM: Track search_bar event with reset (all null)
-  trackSearchBar({
-    destination: null,
-    typeVoyage: null,
-    periode: null,
-    voyageGaranti: false,
-  })
 
-  router.push({
-    path: '/voyages',
-    query: null,
-  })
+function reinitiliazeFilter() {
+  trackSearchBar({ destination: null, typeVoyage: null, periode: null, voyageGaranti: false })
+  router.push({ path: '/voyages', query: null })
 }
 
+// ---------- confirmedOnly <-> route.query.confirmed sync ----------
 watch(confirmedOnly, (newValue) => {
   const query = { ...route.query }
-  if (newValue) {
-    query.confirmed = 'true'
-  }
-  else {
-    delete query.confirmed
-  }
+  if (newValue) query.confirmed = 'true'
+  else delete query.confirmed
   router.push({
     path: route.path,
     query: Object.keys(query).length > 0 ? query : undefined,
@@ -466,20 +373,77 @@ watch(() => route.query.confirmed, (value) => {
 </script>
 
 <style scoped>
-.reset-btn-size {
-  height: 35px!important;
-  width: 150px!important;
+.wrap {
+  max-width: 1180px!important;
 }
-@media (max-width: 900px) {
-  .reset-btn-size {
-    height: 48px!important;
-    width: 120px!important;
-  }
+.crumb {
+  font-size: 13px;
+  color: #9aa0a1;
+  margin: 0 0 16px;
 }
+.crumb a {
+  text-decoration: none;
+  color: #9aa0a1;
+}
+.h1 {
+  font-size: 30px;
+  font-weight: 700;
+  margin: 0 0 10px;
+  color: #222223;
+  letter-spacing: -.01em;
+}
+.lead {
+  font-size: 16px;
+  line-height: 1.7;
+  color: #5d6566;
+  margin: 0 0 26px;
+  max-width: 760px;
+}
+
+.selector-skeleton {
+  height: 76px;
+  border: 1px solid rgba(43, 76, 82, .24);
+  border-radius: 14px;
+  background: #fff;
+}
+
+.resbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 22px 0 4px;
+  flex-wrap: wrap;
+}
+.resbar .n {
+  font-size: 18px;
+  font-weight: 700;
+  color: rgb(var(--v-theme-primary));
+  margin-right: 6px;
+}
+.tag {
+  font-size: 12px;
+  padding: 4px 8px 4px 11px;
+  border-radius: 20px;
+  background: #E7EEED;
+  color: #2B4C52;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 500;
+}
+.tag .v-icon {
+  cursor: pointer;
+}
+.garanti-check {
+  flex: 0 0 auto;
+}
+.reset-btn {
+  flex: 0 0 auto;
+}
+
 @media (max-width: 600px) {
-  .reset-btn-size {
-    height: 38px!important;
-    width: 110px!important;
+  .h1 {
+    font-size: 25px;
   }
 }
 </style>


### PR DESCRIPTION
Rework the voyages search page to match the client's prototype:
- New VoyageSelectorBar component: desktop dropdown panels + mobile bottom-sheet, with destination (multi-select, region-grouped thumbnails), travel type (format + activity categories) and period (seasons + months)
- Extract filtering into useVoyageFilters composable, shared between the page and the selector's live result counter
- Multi-select destinations via comma-separated slugs; new `activities` query param backed by voyage categories; backward-compatible with legacy single-destination / region / travelType / from links
- Replace hero + SearchField with breadcrumb + H1 + lead text
- Removable result chips, "Départs garantis" toggle in the results bar
- Dropdown open/close animation, 70vh max-height with internal scroll and pinned footer
- Preserve GTM search_bar / view_item_list tracking