### PR TITLE
feat(funnel): centralized error reporting with precise origin + Slack

### DIFF
--- a/app/components/AppSnackbar.vue
+++ b/app/components/AppSnackbar.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-snackbar
+    v-model="state.show"
+    :color="state.color"
+    :timeout="state.timeout"
+    location="top"
+  >
+    {{ state.text }}
+    <template #actions>
+      <v-btn
+        variant="text"
+        icon
+        @click="close"
+      >
+        <v-icon>{{ mdiClose }}</v-icon>
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+
+<script setup>
+import { mdiClose } from '@mdi/js'
+
+const { state, close } = useSnackbar()
+</script>

--- a/app/components/Funnel/CheckoutStepper.vue
+++ b/app/components/Funnel/CheckoutStepper.vue
@@ -148,6 +148,7 @@ const { voyage, initialDealValues } = defineProps({
 })
 
 const route = useRoute()
+const { reportApiError } = useFunnelReporter()
 
 const { step, date_id } = route.query
 
@@ -233,6 +234,12 @@ const fetchInsuranceQuote = async () => {
   }
   catch (e) {
     console.error('Insurance quote failed:', e)
+    reportApiError(e, {
+      code: 'INSURANCE_QUOTE_FAILED',
+      step: 'insurances',
+      origin: { endpoint: '/api/v1/chapka/quote', field: 'iso', received: voyage.iso },
+      message: 'Échec de récupération du devis assurance Chapka',
+    })
   }
 }
 

--- a/app/components/Funnel/Steps/Details.vue
+++ b/app/components/Funnel/Steps/Details.vue
@@ -310,6 +310,7 @@ const onProgressFinished = () => {
 }
 
 const { kickstartDeal, updateDeal, bookedId } = useStepperDeal()
+const { report, reportApiError, setContext } = useFunnelReporter()
 const isOptionMode = ref(false)
 const route = useRoute()
 
@@ -370,6 +371,20 @@ const isValid = computed(() => {
   return hasValidName && hasValidEmail && hasValidTravelers && isPhoneValid.value && hasValidCountry
 })
 
+// Name every field that fails validation, with its current (bad) value, so the
+// report pinpoints exactly what's missing/invalid — e.g. iso (isoContact) empty.
+const collectMissingDetailsFields = () => {
+  const m = model.value
+  const missing = []
+  if (!m.firstName) missing.push({ field: 'firstName', received: m.firstName ?? null })
+  if (!m.lastName) missing.push({ field: 'lastName', received: m.lastName ?? null })
+  if (rules.email(m.email) !== true) missing.push({ field: 'email', received: m.email ?? null, expected: 'email valide' })
+  if (!(m.nbAdults > 0)) missing.push({ field: 'nbAdults', received: m.nbAdults ?? null, expected: '> 0' })
+  if (!isPhoneValid.value) missing.push({ field: 'phone', received: m.phone ?? null, expected: 'téléphone valide' })
+  if (!(m.isoContact && m.isoContact.length > 0)) missing.push({ field: 'isoContact', received: m.isoContact ?? null, expected: 'pays (iso) renseigné' })
+  return missing
+}
+
 const saveToLocalStorage = () => {
   const dataToStore = {
     firstname: model.value.firstName,
@@ -414,6 +429,18 @@ const nbTravelers = computed(() => +model.value.nbAdults + +model.value.nbChildr
 const submitStepData = () => {
   // Validate form
   if (!isValid.value) {
+    // Report each missing/invalid field precisely (field name + bad value).
+    setContext({ email: model.value.email, voyageSlug: voyage?.slug, dateId })
+    const missing = collectMissingDetailsFields()
+    missing.forEach(({ field, received, expected }) => {
+      report({
+        code: 'DETAILS_FIELDS_INCOMPLETE',
+        step: 'details',
+        severity: 'warning',
+        origin: { field, received, expected },
+        message: `Champ « ${field} » manquant ou invalide à l'étape Détails`,
+      })
+    })
     return false
   }
   //  #todo soustraire la réduction s'il y en a une
@@ -541,6 +568,13 @@ const submitStepData = () => {
               }
               catch (err) {
                 console.error('[Details] placeOption error', getApiErrorMessage(err))
+                reportApiError(err, {
+                  code: 'PLACE_OPTION_FAILED',
+                  step: 'option_booking',
+                  origin: { endpoint: '/booking/booked_date/option' },
+                  message: 'Échec de la pose d\'option',
+                  userMessage: 'Impossible de poser l\'option pour le moment. Veuillez réessayer.',
+                })
               }
               updateDeal({
                 stage: '27',
@@ -593,6 +627,12 @@ const submitStepData = () => {
   catch (error) {
     // Handle errors
     console.log('[Details] error updating or creating deal', error)
+    reportApiError(error, {
+      code: 'DETAILS_SUBMIT_FAILED',
+      step: 'details',
+      message: 'Erreur lors de la soumission de l\'étape Détails',
+      userMessage: 'Une erreur est survenue, veuillez réessayer.',
+    })
     shouldAdvance.value = false
     buttonLoading.value = false
     showProgress.value = false

--- a/app/components/Funnel/Steps/Insurances.vue
+++ b/app/components/Funnel/Steps/Insurances.vue
@@ -250,6 +250,7 @@ const { trackReservationStep } = useGtmTracking()
 const { insurances, currentStep, ownStep, page, voyage } = defineProps(['insurances', 'voyage', 'currentStep', 'ownStep', 'page'])
 const isLoadingInsurance = ref(true)
 const { updateDeal } = useStepperDeal()
+const { reportApiError } = useFunnelReporter()
 
 const model = defineModel()
 const emit = defineEmits(['next', 'previous'])
@@ -352,6 +353,11 @@ const submitStepData = () => {
   }
   catch (error) {
     console.log('error updating insurance', error)
+    reportApiError(error, {
+      code: 'INSURANCE_SUBMIT_FAILED',
+      step: 'insurances',
+      message: 'Erreur lors de la soumission du choix d\'assurance',
+    })
     return false
   }
 }

--- a/app/components/Funnel/Steps/PaymentRedirect.vue
+++ b/app/components/Funnel/Steps/PaymentRedirect.vue
@@ -355,6 +355,7 @@ const redirectingToAlma = ref(false)
 const emit = defineEmits(['previous'])
 const model = defineModel()
 const { updateDeal, bookedId: composableBookedId, kickstartLoading } = useStepperDeal()
+const { reportApiError, setContext } = useFunnelReporter()
 const { addSingleParam } = useParams()
 
 const isSurMesure = computed(() => voyage.availabilityTypes?.includes('custom'))
@@ -468,9 +469,16 @@ const stripePay = async () => {
       redirectingToStripe.value = false
     }
   }
-  catch {
+  catch (err) {
     redirectingToStripe.value = false
     paymentError.value = page?.payment?.payment_error || 'Une erreur est survenue. Veuillez réessayer ou nous contacter.'
+    setContext({ bookedId: route.query.booked_id || composableBookedId.value, email: model.value.email, type: route.query.type })
+    reportApiError(err, {
+      code: 'STRIPE_SESSION_FAILED',
+      step: 'payment',
+      origin: { endpoint: '/api/v1/stripe' },
+      message: `Échec de création de la session Stripe (type=${route.query.type})`,
+    })
   }
   finally {
     loadingSession.value = false
@@ -526,9 +534,16 @@ const almaPay = async () => {
       redirectingToAlma.value = false
     }
   }
-  catch {
+  catch (err) {
     redirectingToAlma.value = false
     paymentError.value = page?.payment?.payment_error || 'Une erreur est survenue. Veuillez réessayer ou nous contacter.'
+    setContext({ bookedId: route.query.booked_id || composableBookedId.value, email: model.value.email, type: route.query.type })
+    reportApiError(err, {
+      code: 'ALMA_SESSION_FAILED',
+      step: 'payment',
+      origin: { endpoint: '/api/v1/alma' },
+      message: `Échec de création de la session Alma (type=${route.query.type})`,
+    })
   }
   finally {
     loadingSession.value = false
@@ -552,6 +567,14 @@ const book = async () => {
       return
     }
     console.error(getApiErrorMessage(err, 'Erreur option'))
+    setContext({ bookedId: route.query.booked_id, voyageSlug: voyage.slug })
+    reportApiError(err, {
+      code: 'PLACE_OPTION_FAILED',
+      step: 'option_booking',
+      origin: { endpoint: '/booking/booked_date/option' },
+      message: 'Échec de la pose d\'option (étape paiement)',
+      userMessage: 'Impossible de poser l\'option pour le moment. Veuillez réessayer.',
+    })
   }
   const dealData = {
     stage: '27',

--- a/app/components/Funnel/Steps/TravelersInfos.vue
+++ b/app/components/Funnel/Steps/TravelersInfos.vue
@@ -91,11 +91,15 @@
 
 <script setup>
 import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat.js'
+
+dayjs.extend(customParseFormat)
 
 const { trackReservationStep } = useGtmTracking()
 
 const { voyage, currentStep, ownStep, page } = defineProps(['voyage', 'currentStep', 'ownStep', 'page', 'initialDealValues'])
 const { updateDeal } = useStepperDeal(ownStep)
+const { report, reportApiError } = useFunnelReporter()
 const route = useRoute()
 const model = defineModel()
 
@@ -245,12 +249,54 @@ const submitStepData = () => {
         adults: ageValidation.value.adultsCount,
       },
     })
+    // Pinpoint a malformed birthdate (parsing failure) before blaming counts.
+    const badBirthdate = travelers.value.findIndex(
+      t => t.birthdate && !dayjs(t.birthdate, 'DD/MM/YYYY', true).isValid(),
+    )
+    if (badBirthdate !== -1) {
+      report({
+        code: 'BIRTHDATE_PARSE_FAILED',
+        step: 'travelers',
+        severity: 'warning',
+        origin: {
+          field: `traveler${badBirthdate + 1}.birthdate`,
+          expected: 'DD/MM/YYYY',
+          received: travelers.value[badBirthdate].birthdate,
+        },
+        message: 'Date de naissance voyageur au mauvais format',
+      })
+    }
+    else {
+      report({
+        code: 'TRAVELER_AGE_MISMATCH',
+        step: 'travelers',
+        severity: 'warning',
+        origin: {
+          field: 'nbAdults/nbChildren',
+          expected: `adults=${+model.value.nbAdults}, children=${+model.value.nbChildren}`,
+          received: `adults=${ageValidation.value.adultsCount}, children=${ageValidation.value.childrenCount}`,
+        },
+        message: 'Répartition adultes/enfants des voyageurs incohérente avec l\'étape 1',
+      })
+    }
     return false
   }
 
   // Validate all fields are filled
   if (!allFieldsFilled.value) {
     console.error('Not all traveler fields are filled')
+    travelers.value.forEach((t, i) => {
+      const missingField = !t.firstname ? 'firstname' : !t.lastname ? 'lastname' : !t.birthdate ? 'birthdate' : !t.isoContact ? 'isoContact' : null
+      if (missingField) {
+        report({
+          code: 'TRAVELER_FIELDS_INCOMPLETE',
+          step: 'travelers',
+          severity: 'warning',
+          origin: { field: `traveler${i + 1}.${missingField}`, received: t[missingField] ?? null },
+          message: `Champ « ${missingField} » manquant pour le voyageur ${i + 1}`,
+        })
+      }
+    })
     return false
   }
 
@@ -282,6 +328,12 @@ const submitStepData = () => {
   }
   catch (error) {
     console.error('Error updating travelers info', error)
+    reportApiError(error, {
+      code: 'TRAVELERS_SUBMIT_FAILED',
+      step: 'travelers',
+      message: 'Erreur lors de la soumission des informations voyageurs',
+      userMessage: 'Une erreur est survenue, veuillez réessayer.',
+    })
     return false
   }
 }

--- a/app/components/FunnelErrorTester.vue
+++ b/app/components/FunnelErrorTester.vue
@@ -1,0 +1,224 @@
+<template>
+  <div
+    v-if="visible"
+    class="funnel-error-tester"
+  >
+    <v-btn
+      v-if="!open"
+      size="small"
+      color="error"
+      class="toggle"
+      :prepend-icon="mdiBugOutline"
+      @click="open = true"
+    >
+      Test erreurs
+    </v-btn>
+
+    <v-card
+      v-else
+      class="panel pa-3"
+      elevation="10"
+      width="280"
+    >
+      <div class="d-flex align-center justify-space-between mb-2">
+        <strong class="text-caption text-uppercase">Test erreurs funnel</strong>
+        <v-btn
+          icon
+          size="x-small"
+          variant="text"
+          @click="open = false"
+        >
+          <v-icon>{{ mdiClose }}</v-icon>
+        </v-btn>
+      </div>
+
+      <p class="text-caption text-medium-emphasis mb-2">
+        {{ isAdmin ? `Admin : ${adminEmail}` : 'Mode dev' }} — chaque bouton génère un report réel (console + Slack si configuré).
+      </p>
+
+      <v-text-field
+        v-model="testDealId"
+        density="compact"
+        variant="outlined"
+        hide-details
+        label="Deal ID (test)"
+        class="mb-3"
+      />
+
+      <div class="d-flex flex-column ga-2">
+        <v-btn
+          v-for="t in tests"
+          :key="t.code"
+          size="small"
+          variant="tonal"
+          :color="t.color"
+          :loading="loadingCode === t.code"
+          class="justify-start text-none"
+          @click="run(t)"
+        >
+          {{ t.label }}
+        </v-btn>
+      </div>
+
+      <v-alert
+        v-if="lastStatus"
+        :type="lastStatus.type"
+        density="compact"
+        variant="tonal"
+        class="mt-3 text-caption"
+      >
+        {{ lastStatus.text }}
+      </v-alert>
+    </v-card>
+  </div>
+</template>
+
+<script setup>
+import { mdiClose, mdiBugOutline } from '@mdi/js'
+
+const config = useRuntimeConfig()
+const route = useRoute()
+const { report, reportApiError, setContext } = useFunnelReporter()
+
+const visible = ref(false)
+const open = ref(false)
+const isAdmin = ref(false)
+const adminEmail = ref('')
+const loadingCode = ref(null)
+const lastStatus = ref(null)
+const testDealId = ref('999999')
+
+// Gate: visible for logged-in @odysway.com admins (booking session cookie) or
+// in any non-production environment for local testing.
+onMounted(async () => {
+  const isDev = config.public.environment !== 'production'
+  try {
+    const res = await $fetch('/api/v1/auth/check')
+    if (res?.success) {
+      isAdmin.value = true
+      adminEmail.value = res.user?.email || ''
+    }
+  }
+  catch {
+    // not logged in — fall through to dev gate
+  }
+  visible.value = isAdmin.value || isDev
+})
+
+// Seed the funnel context so reports carry a (test) dealId + the real URL.
+const seedContext = () => {
+  setContext({
+    dealId: testDealId.value || undefined,
+    email: 'admin-test@odysway.com',
+    voyageSlug: route.query.voyage || undefined,
+    type: route.query.type || undefined,
+  })
+}
+
+// A "server" test fires a real failing request; reportApiError merges the
+// precise origin the endpoint attached (funnelCreateError) into a single report.
+const callAndReport = async (fn, step) => {
+  try {
+    await fn()
+    return false
+  }
+  catch (err) {
+    reportApiError(err, { step })
+    return true
+  }
+}
+
+const tests = [
+  {
+    code: 'TEST_CLIENT_ISO_MISSING',
+    label: 'Client · champ iso manquant',
+    color: 'warning',
+    fire: () => report({
+      code: 'DETAILS_FIELDS_INCOMPLETE',
+      step: 'details',
+      severity: 'warning',
+      origin: { field: 'isoContact', received: null, expected: 'pays (iso) renseigné' },
+      message: '[TEST] Champ iso manquant à l\'étape Détails',
+      userMessage: '[TEST] Merci de renseigner votre pays.',
+    }),
+  },
+  {
+    code: 'TEST_CLIENT_FATAL',
+    label: 'Client · erreur fatale',
+    color: 'error',
+    fire: () => report({
+      code: 'TEST_FATAL',
+      step: 'unknown',
+      severity: 'fatal',
+      origin: { field: 'demo', received: undefined },
+      message: '[TEST] Erreur fatale simulée depuis le menu admin',
+    }),
+  },
+  {
+    code: 'TEST_SERVER_ZOD',
+    label: 'Serveur · validation Zod (/ac/deals)',
+    color: 'deep-purple',
+    fire: () => callAndReport(
+      () => apiRequest('/ac/deals', 'post', { title: 'TEST' }),
+      'details',
+    ),
+  },
+  {
+    code: 'TEST_SERVER_STRIPE',
+    label: 'Serveur · Stripe booked_date introuvable',
+    color: 'indigo',
+    fire: () => callAndReport(
+      () => $fetch('/api/v1/stripe?bookedId=__test_invalid__', { method: 'POST', body: {} }),
+      'payment',
+    ),
+  },
+  {
+    code: 'TEST_SERVER_CHAPKA',
+    label: 'Serveur · devis assurance KO',
+    color: 'teal',
+    fire: () => callAndReport(
+      () => apiRequest('/chapka/quote', 'post', {}),
+      'insurances',
+    ),
+  },
+  {
+    code: 'TEST_SERVER_DATE',
+    label: 'Serveur · date introuvable',
+    color: 'blue-grey',
+    fire: () => callAndReport(
+      () => apiRequest('/booking/date/__test_invalid__'),
+      'init',
+    ),
+  },
+]
+
+const run = async (t) => {
+  loadingCode.value = t.code
+  lastStatus.value = null
+  seedContext()
+  try {
+    await t.fire()
+    lastStatus.value = { type: 'success', text: `Report envoyé : ${t.label}` }
+  }
+  catch (err) {
+    lastStatus.value = { type: 'error', text: `Échec du test : ${err?.message || err}` }
+  }
+  finally {
+    loadingCode.value = null
+  }
+}
+</script>
+
+<style scoped>
+.funnel-error-tester {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 2147483000;
+}
+
+.panel {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+</style>

--- a/app/composables/useFunnelReporter.js
+++ b/app/composables/useFunnelReporter.js
@@ -1,0 +1,94 @@
+// Client-side funnel error reporter. Holds shared funnel context (dealId,
+// bookedId, email, slug…) that each step enriches as data becomes known, and
+// forwards structured errors to the server sink. Optionally surfaces a
+// user-facing snackbar, kept decoupled from the (detailed) internal report.
+//
+// INVARIANT: reporting must never break the funnel — a failed report only logs.
+export function useFunnelReporter() {
+  const context = useState('funnelReporter:context', () => ({}))
+  const { notifyError } = useSnackbar()
+
+  const setContext = (partial = {}) => {
+    const next = { ...context.value }
+    for (const [key, value] of Object.entries(partial)) {
+      if (value !== undefined && value !== null && value !== '') next[key] = value
+    }
+    context.value = next
+  }
+
+  const buildPayload = ({ code, step = 'unknown', origin = {}, message = '', severity = 'error', raw }) => ({
+    code,
+    step,
+    origin,
+    message,
+    severity,
+    raw,
+    source: 'client',
+    occurredAt: new Date().toISOString(),
+    context: {
+      ...context.value,
+      url: import.meta.client ? window.location.href : context.value.url,
+    },
+  })
+
+  const send = async (payload) => {
+    try {
+      await apiRequest('/monitoring/funnel-error', 'post', payload)
+    }
+    catch (err) {
+      // Never let a reporting failure cascade into the funnel.
+      console.error('[useFunnelReporter] failed to send report', err)
+    }
+  }
+
+  const report = ({ userMessage, ...rest }) => {
+    const payload = buildPayload(rest)
+    if (userMessage) notifyError(userMessage)
+    // Fire-and-forget — reporting must not block the UI.
+    send(payload)
+    return payload
+  }
+
+  // Flatten a $fetch error (enriched with `__funnel` by apiRequest) into a
+  // precise report: endpoint, status code, server statusMessage, stack.
+  const reportApiError = (err, { code, step = 'unknown', origin = {}, message, severity = 'error', userMessage } = {}) => {
+    const funnelMeta = err?.__funnel || {}
+    // The server may attach a precise, structured origin (e.g. the exact Zod
+    // field) via funnelCreateError → merge it so the single client report names
+    // the culpable field alongside our URL/dealId context.
+    const serverFunnel = err?.data?.funnel ? err.data : null
+    const serverMessage = err?.data?.statusMessage || err?.data?.message || err?.statusMessage || err?.message
+    return report({
+      code: code || serverFunnel?.code || 'API_ERROR',
+      step: step !== 'unknown' ? step : (serverFunnel?.step || 'unknown'),
+      severity,
+      userMessage,
+      message: message || serverMessage || 'Erreur API',
+      origin: {
+        endpoint: funnelMeta.endpoint,
+        statusCode: funnelMeta.statusCode ?? err?.statusCode,
+        ...(serverFunnel?.origin || {}),
+        ...origin,
+      },
+      raw: {
+        name: err?.name,
+        message: err?.message,
+        stack: err?.stack,
+        data: err?.data,
+      },
+    })
+  }
+
+  // Wrap a handler so any throw is reported (with context) then re-thrown.
+  const wrapStep = async (step, fn, { code = 'STEP_FAILED', userMessage } = {}) => {
+    try {
+      return await fn()
+    }
+    catch (err) {
+      reportApiError(err, { code, step, userMessage })
+      throw err
+    }
+  }
+
+  return { context, setContext, report, reportApiError, wrapStep }
+}

--- a/app/composables/useSnackbar.js
+++ b/app/composables/useSnackbar.js
@@ -1,0 +1,25 @@
+// Lightweight global snackbar for user-facing notifications inside the funnel.
+// State is shared via useState so any component/composable can trigger it and a
+// single <AppSnackbar> (mounted in the funnel layout) renders it.
+export function useSnackbar() {
+  const state = useState('snackbar:state', () => ({
+    show: false,
+    text: '',
+    color: 'error',
+    timeout: 6000,
+  }))
+
+  const notify = ({ text, color = 'info', timeout = 6000 }) => {
+    state.value = { show: true, text, color, timeout }
+  }
+
+  const notifyError = (text = 'Une erreur est survenue, veuillez réessayer.') => {
+    notify({ text, color: 'error', timeout: 8000 })
+  }
+
+  const close = () => {
+    state.value = { ...state.value, show: false }
+  }
+
+  return { state, notify, notifyError, close }
+}

--- a/app/composables/useStepperDeal.js
+++ b/app/composables/useStepperDeal.js
@@ -13,6 +13,7 @@ export function useStepperDeal() {
 
   const route = useRoute()
   const { addMultipleParams } = useParams()
+  const { report, reportApiError, setContext } = useFunnelReporter()
 
   const fetchDeal = async (id = dealId.value) => {
     loadingDeal.value = true
@@ -51,6 +52,7 @@ export function useStepperDeal() {
 
         dealId.value = addedBookedDate.deal_id
         bookedId.value = addedBookedDate.id
+        setContext({ dealId: addedBookedDate.deal_id, bookedId: addedBookedDate.id, dateId })
         localStorage.setItem(dateId, JSON.stringify({
           booked_id: addedBookedDate.id,
           deal_id: addedBookedDate.deal_id,
@@ -76,6 +78,12 @@ export function useStepperDeal() {
 
     assignStatus.value = 'failed'
     assignError.value = lastError
+    reportApiError(lastError, {
+      code: 'ASSIGN_DEAL_EXHAUSTED',
+      step: 'details',
+      origin: { endpoint: `/booking/${slug}/date/${dateId}/assign-deal` },
+      message: `assign-deal failed after ${maxAttempts} attempts (dealId=${dealIdToAssign}, nbTravelers=${nbTravelers})`,
+    })
     return null
   }
 
@@ -87,6 +95,7 @@ export function useStepperDeal() {
   const createDeal = async (body) => {
     try {
       const res = await apiRequest('/ac/deals', 'post', body)
+      setContext({ dealId: res, email: body?.email, voyageSlug: body?.slug })
       const date_id = route.query.date_id
       const addedBookedDate = await assignDealWithRetry({
         slug: body.slug,
@@ -115,6 +124,12 @@ export function useStepperDeal() {
       console.error('Error creating deal:', error)
       assignStatus.value = 'failed'
       assignError.value = error
+      reportApiError(error, {
+        code: 'CREATE_DEAL_FAILED',
+        step: 'details',
+        origin: { endpoint: '/ac/deals' },
+        message: 'Échec de création du deal ActiveCampaign',
+      })
       return false
     }
   }
@@ -125,6 +140,7 @@ export function useStepperDeal() {
       const res = await apiRequest(`/booking/${slug}/date/${dateId}/kickstart`, 'post', body)
       dealId.value = res.dealId
       bookedId.value = res.bookedId
+      setContext({ dealId: res.dealId, bookedId: res.bookedId, dateId, voyageSlug: slug, email: body?.email })
       localStorage.setItem(dateId, JSON.stringify({ booked_id: res.bookedId, deal_id: res.dealId }))
       addMultipleParams({ booked_id: res.bookedId, date_id: undefined })
       // Flush any updateDeal calls that arrived before bookedId was set
@@ -137,6 +153,15 @@ export function useStepperDeal() {
       }
       return res
     }
+    catch (error) {
+      reportApiError(error, {
+        code: 'KICKSTART_FAILED',
+        step: 'details',
+        origin: { endpoint: `/booking/${slug}/date/${dateId}/kickstart` },
+        message: 'Échec du kickstart deal',
+      })
+      throw error
+    }
     finally {
       kickstartLoading.value = false
     }
@@ -146,6 +171,13 @@ export function useStepperDeal() {
     const currentBookedId = explicitBookedId || route.query.booked_id || bookedId.value
     if (!currentBookedId) {
       pendingUpdates.value.push(body)
+      report({
+        code: 'UPDATE_DEAL_QUEUED_NO_BOOKED_ID',
+        step: 'unknown',
+        severity: 'warning',
+        origin: { field: 'bookedId', received: null },
+        message: 'updateDeal appelé sans bookedId — mise en file d\'attente',
+      })
       return false
     }
     await apiRequest('/ac/deals/update-with-bms?bookedId=' + currentBookedId, 'post', body)

--- a/app/layouts/funnel.vue
+++ b/app/layouts/funnel.vue
@@ -4,10 +4,30 @@
     <v-main class="main-content bg-warm">
       <slot />
     </v-main>
+    <AppSnackbar />
+    <ClientOnly>
+      <FunnelErrorTester />
+    </ClientOnly>
   </v-app>
 </template>
 
 <script setup>
+// Funnel-scoped safety net: any error thrown while rendering a funnel child
+// component is reported with its Vue origin (`info`). Scoped to this layout so
+// it never spams from the rest of the app. Return false to keep propagating.
+const { report } = useFunnelReporter()
+
+onErrorCaptured((err, _instance, info) => {
+  report({
+    code: 'VUE_RENDER_ERROR',
+    step: 'unknown',
+    severity: 'fatal',
+    origin: { field: info },
+    message: err?.message || 'Erreur de rendu',
+    raw: { name: err?.name, message: err?.message, stack: err?.stack },
+  })
+  return false
+})
 </script>
 
 <style scoped>

--- a/app/pages/checkout/index.vue
+++ b/app/pages/checkout/index.vue
@@ -87,6 +87,7 @@ useSeoMeta({
 
 const route = useRoute()
 const { travelTitle } = useFunnelHeader()
+const { report, reportApiError, setContext } = useFunnelReporter()
 
 const checkoutStepperRef = useTemplateRef('checkoutStepperRef')
 
@@ -134,12 +135,24 @@ catch (err) {
 
 // 🚀 2. Build voyage (from AC or Sanity)
 const initCheckout = async () => {
+  // Seed context so every report from here on carries the funnel identifiers.
+  setContext({ bookedId, dateId, voyageSlug })
   try {
     loading.value = true
     if (bookedId) {
       // ActiveCampaign deal checkout
       const deal = await apiRequest(`/ac/deals/deal-from-bms?bookedId=${bookedId}`)
-      if (!deal) throw new Error(`No deal found with bookedId ${bookedId}`)
+      if (!deal) {
+        report({
+          code: 'AC_DEAL_FROM_BMS_EMPTY',
+          step: 'init',
+          severity: 'fatal',
+          origin: { field: 'deal', endpoint: '/ac/deals/deal-from-bms', received: bookedId },
+          message: `Aucun deal trouvé pour bookedId ${bookedId}`,
+        })
+        throw new Error(`No deal found with bookedId ${bookedId}`)
+      }
+      setContext({ dealId: deal?.id, voyageSlug: deal?.slug })
       dealValues.value = buildDynamicDealValues(deal)
       voyage.value = buildVoyageFromAC(deal, imgSrc.value)
       travelTitle.value = voyage.value?.title || ''
@@ -149,6 +162,18 @@ const initCheckout = async () => {
       const fetchedDate = await apiRequest(`/booking/date/${dateId}`)
       const bookedSeat = Number(fetchedDate.booked_seat || 0)
       const maxTravelers = Number(fetchedDate.max_traveler ?? fetchedDate.max_travelers ?? 0)
+      if (Number.isNaN(bookedSeat) || Number.isNaN(maxTravelers)) {
+        report({
+          code: 'DATE_SEAT_NAN',
+          step: 'init',
+          origin: {
+            field: Number.isNaN(maxTravelers) ? 'max_traveler' : 'booked_seat',
+            received: Number.isNaN(maxTravelers) ? fetchedDate.max_traveler : fetchedDate.booked_seat,
+            expected: 'nombre',
+          },
+          message: 'Valeur de places non numérique sur la date',
+        })
+      }
       if (maxTravelers > 0 && bookedSeat >= maxTravelers) {
         await navigateTo({
           path: '/checkout/complet',
@@ -167,10 +192,24 @@ const initCheckout = async () => {
         dealValues.value = buildDynamicDealValues()
       }
       else {
+        report({
+          code: 'SANITY_TRAVEL_MISSING',
+          step: 'init',
+          severity: 'fatal',
+          origin: { field: 'travelSanity', received: voyageSlug || fetchedDate.travel_slug, endpoint: '/sanity' },
+          message: 'Voyage Sanity introuvable pour le slug',
+        })
         throw new Error(`Date not found for ${voyageSlug || fetchedDate.travel_slug}`)
       }
     }
     else {
+      report({
+        code: 'MISSING_QUERY_PARAMS',
+        step: 'init',
+        severity: 'fatal',
+        origin: { field: 'date_id|booked_id', received: null, expected: 'date_id ou booked_id dans l\'URL' },
+        message: 'Paramètres de requête manquants sur /checkout',
+      })
       throw new Error('Missing required query parameters')
     }
     loading.value = false
@@ -179,6 +218,11 @@ const initCheckout = async () => {
     loading.value = false
     console.error('Error building voyage:', err)
     error.value = err.message
+    // Backstop: report any init failure not already covered above (e.g. a
+    // network failure on one of the fetches) with its API origin.
+    if (err?.__funnel) {
+      reportApiError(err, { code: 'INIT_CHECKOUT_FAILED', step: 'init', message: 'Échec d\'initialisation du checkout' })
+    }
   }
 }
 

--- a/app/utils/apiRequest.js
+++ b/app/utils/apiRequest.js
@@ -8,6 +8,19 @@ export default async function (endpoint, method = 'get', body = null) {
   }
   catch (error) {
     console.error(`API Error in ${endpoint}:`, error)
+    // Attach structured metadata so useFunnelReporter can report a precise
+    // origin (endpoint + status) without each call site repeating it.
+    try {
+      error.__funnel = {
+        endpoint,
+        method,
+        statusCode: error?.statusCode,
+        data: error?.data,
+      }
+    }
+    catch {
+      // error may be a non-extensible value — ignore.
+    }
     throw error
   }
 }

--- a/exemple.env
+++ b/exemple.env
@@ -23,6 +23,9 @@ GOOGLE_ANALYTICS_TID_LIVE='your-google-analytics-tid-live'
 SLACK_URL_PAIEMENTS='your-slack-url-paiements'
 SLACK_URL_POSE_OPTION='your-slack-url-pose-option'
 SLACK_URL_DEVIS='your-slack-url-devis'
+# Webhook dédié aux erreurs du funnel de checkout (reporting détaillé).
+# Tant que vide, les erreurs sont seulement loggées en console (pas d'envoi Slack).
+SLACK_URL_FUNNEL_ERRORS='your-slack-url-funnel-errors'
 
 NUXT_URL_HASH_SECRET='your-nuxt-url-hash-secret'
 

--- a/server/api/v1/ac/deals/deal-from-bms.get.js
+++ b/server/api/v1/ac/deals/deal-from-bms.get.js
@@ -9,9 +9,12 @@ export default defineEventHandler(async (event) => {
     .eq('id', bookedId)
     .single()
   if (error) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error getting deal from booked_dates',
+      code: 'DEAL_FROM_BMS_NOT_FOUND',
+      step: 'init',
+      origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
+      message: 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   try {
@@ -26,9 +29,12 @@ export default defineEventHandler(async (event) => {
     const contact = fullContact.contact
 
     if (!fetchedDeal.deal || !customFields) {
-      throw createError({
+      throw funnelReporter.funnelCreateError({
         statusCode: 404,
-        message: 'Deal not found',
+        code: 'DEAL_FROM_BMS_EMPTY',
+        step: 'init',
+        origin: { field: 'deal', received: data.deal_id },
+        message: 'Deal AC introuvable ou champs personnalisés manquants',
       })
     }
     return {
@@ -45,9 +51,14 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     console.log('Error getting deal from booked_dates', err)
-    throw createError({
+    // Re-throw an already-instrumented funnel error untouched (keeps its code).
+    if (err?.data?.code) throw err
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error getting deal from booked_dates',
+      code: 'DEAL_FROM_BMS_FETCH_FAILED',
+      step: 'init',
+      origin: { field: 'deal', received: data.deal_id },
+      message: 'Erreur lors de la récupération du deal depuis ActiveCampaign',
     })
   }
 })

--- a/server/api/v1/ac/deals/index.post.ts
+++ b/server/api/v1/ac/deals/index.post.ts
@@ -12,9 +12,14 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
   if (!parsedBody.success) {
     console.error('Deal creation validation error:', parsedBody.error)
     console.log('error on', parsedBody.data)
-    throw createError({
+    // Precise origin: the exact failing field(s) from Zod, surfaced to the
+    // client (and Slack) instead of a generic "validation failed".
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      message: `Validation failed: ${parsedBody.error.message}`,
+      code: 'ZOD_VALIDATION',
+      step: 'details',
+      origin: funnelReporter.zodToOrigin(parsedBody.error),
+      message: `Validation du deal échouée — ${funnelReporter.zodIssuesSummary(parsedBody.error)}`,
     })
   }
 
@@ -26,9 +31,12 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
   }
   catch (err) {
     console.error('=======Deal creation error=======', err)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 500,
-      message: 'Failed to create deal',
+      code: 'AC_CREATE_DEAL_FAILED',
+      step: 'details',
+      origin: { endpoint: '/ac/deals' },
+      message: 'Échec de création du deal côté ActiveCampaign',
     })
   }
 })

--- a/server/api/v1/ac/deals/update-with-bms.post.ts
+++ b/server/api/v1/ac/deals/update-with-bms.post.ts
@@ -10,9 +10,12 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
     .single()
 
   if (error) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error getting deal from booked_dates',
+      code: 'UPDATE_BMS_BOOKED_DATE_NOT_FOUND',
+      step: 'unknown',
+      origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
+      message: 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   if (event.method !== 'POST') {
@@ -24,23 +27,32 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
 
   const dealId = data.deal_id
   if (!dealId) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
+      code: 'UPDATE_BMS_NO_DEALID',
+      step: 'unknown',
+      origin: { field: 'dealId', received: null },
       message: 'Deal ID is required',
     })
   }
   if (!Number.isInteger(+dealId)) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Deal ID should be an integer',
+      code: 'UPDATE_BMS_DEALID_NOT_INT',
+      step: 'unknown',
+      origin: { field: 'dealId', received: dealId, expected: 'entier' },
+      message: 'Deal ID should be an integer',
     })
   }
   const parsedBody = await readValidatedBody(event, body => UpdateDealSchema.safeParse(body))
   if (!parsedBody.success) {
     console.error('Validation failed:', parsedBody.error)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      message: `Validation failed: ${parsedBody.error.message}`,
+      code: 'UPDATE_BMS_ZOD_VALIDATION',
+      step: 'unknown',
+      origin: funnelReporter.zodToOrigin(parsedBody.error),
+      message: `Validation de mise à jour échouée — ${funnelReporter.zodIssuesSummary(parsedBody.error)}`,
     })
   }
   try {
@@ -50,9 +62,12 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
   }
   catch (err) {
     console.error('Deal updating error:', err)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 500,
-      message: 'Failed to update deal',
+      code: 'UPDATE_BMS_FAILED',
+      step: 'unknown',
+      origin: { endpoint: 'activecampaign.updateDeal' },
+      message: 'Échec de mise à jour du deal',
     })
   }
 })

--- a/server/api/v1/alma/index.post.js
+++ b/server/api/v1/alma/index.post.js
@@ -9,9 +9,12 @@ export default defineEventHandler(async (event) => {
     .single()
 
   if (error) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error getting deal from booked_dates',
+      code: 'ALMA_BOOKED_DATE_NOT_FOUND',
+      step: 'payment',
+      origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
+      message: 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   const deal_id = data.deal_id
@@ -20,9 +23,12 @@ export default defineEventHandler(async (event) => {
   console.log('========ALMA REQUEST BODY=======', body)
 
   if (!body.dealId) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'dealId is required',
+      code: 'ALMA_NO_DEALID',
+      step: 'payment',
+      origin: { field: 'dealId', received: null },
+      message: 'dealId is required',
     })
   }
 
@@ -36,10 +42,12 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     console.log('Error creating alma session', err)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error creating alma session',
-      data: { details: err.message },
+      code: 'ALMA_SESSION_CREATE_FAILED',
+      step: 'payment',
+      origin: { endpoint: 'alma.createAlmaSession' },
+      message: `Échec de création de la session Alma (dealId=${body.dealId}): ${err.message}`,
     })
   }
 })

--- a/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
@@ -11,11 +11,11 @@ export default defineEventHandler(async (event) => {
 
   const { dateId, slug } = event.context.params
   if (!dateId || !slug) {
-    throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'ASSIGN_NO_PARAMS', step: 'details', origin: { field: 'slug|dateId', received: { slug, dateId } }, message: 'slug et dateId requis' })
   }
   const { dealId, booked_places, is_option, expiracy_date, nbTravelers: bodyNbTravelers, alreadyPaid: bodyAlreadyPaid } = await readBody(event)
   if (!dealId) {
-    throw createError({ statusCode: 400, statusMessage: 'dealId requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'ASSIGN_NO_DEALID', step: 'details', origin: { field: 'dealId', received: null }, message: 'dealId requis' })
   }
   const origin = config.public.siteURL
   const skipAcFetch = typeof bodyNbTravelers === 'number' && typeof bodyAlreadyPaid === 'number'
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
     .eq('travel_slug', slug)
     .single()
   if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
+    throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'ASSIGN_DATE_NOT_FOUND', step: 'details', origin: { field: 'dateId', received: dateId, endpoint: `/booking/${slug}/date/${dateId}/assign-deal` }, message: 'Date introuvable pour ce slug' })
   }
 
   // When client provides nbTravelers/alreadyPaid, skip the AC fetch (~300-400ms saved)
@@ -52,15 +52,15 @@ export default defineEventHandler(async (event) => {
     }
     catch {
       console.error(`[assign-deal] AC fetch FAILED dealId=${dealId} after ${Date.now() - acFetchStart}ms`)
-      throw createError({ statusCode: 502, statusMessage: 'Erreur lors de la récupération du deal AC' })
+      throw funnelReporter.funnelCreateError({ statusCode: 502, code: 'ASSIGN_AC_FETCH_FAILED', step: 'details', origin: { field: 'dealId', received: dealId }, message: 'Erreur lors de la récupération du deal AC' })
     }
-    if (!deal) throw createError({ statusCode: 404, statusMessage: 'Deal introuvable' })
+    if (!deal) throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'ASSIGN_DEAL_NOT_FOUND', step: 'details', origin: { field: 'deal', received: dealId }, message: 'Deal introuvable' })
     nbTravelers = +deal.nbTravelers
     alreadyPaid = +deal.alreadyPaid
     console.log(`[assign-deal] AC fetch done dealId=${dealId} in ${Date.now() - acFetchStart}ms`)
   }
 
-  if (!nbTravelers) throw createError({ statusCode: 400, statusMessage: 'Le deal ne contient pas nbTravelers' })
+  if (!nbTravelers) throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'ASSIGN_NO_NB_TRAVELERS', step: 'details', origin: { field: 'nbTravelers', received: nbTravelers }, message: 'Le deal ne contient pas nbTravelers' })
 
   // If user placed an option or already paid, he is counted as a booked traveler, otherwise he is just assigned to the deal temporarily
   const bookedPlaceCount = (alreadyPaid > 0 || is_option === true) ? (booked_places || Number(nbTravelers)) : 0
@@ -88,19 +88,20 @@ export default defineEventHandler(async (event) => {
       .eq('deal_id', dealId)
       .single()
     if (existingError || !existingBookedDate?.travel_dates) {
-      throw createError({ statusCode: 409, statusMessage: 'Deal déjà assigné' })
+      throw createError({ statusCode: 409, statusMessage: 'Deal déjà assigné', data: { code: 'ASSIGN_DUPLICATE' } })
     }
     throw createError({
       statusCode: 409,
       statusMessage: 'Deal déjà assigné à une autre date',
       data: {
+        code: 'ASSIGN_DUPLICATE_OTHER_DATE',
         redirectTo: `/booking-management/${existingBookedDate.travel_dates.travel_slug}/${existingBookedDate.travel_dates.id}`,
       },
     })
   }
   else if (error) {
     console.error(`[assign-deal] Supabase insert FAILED dealId=${dealId}`, error.message)
-    throw createError({ statusCode: 500, statusMessage: error.message })
+    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'ASSIGN_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.insert' }, message: error.message })
   }
 
   // Update travel_dates.booked_seat

--- a/server/api/v1/booking/[slug]/date/[dateId]/kickstart.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/kickstart.post.js
@@ -6,14 +6,14 @@ export default defineEventHandler(async (event) => {
 
   const { dateId, slug } = event.context.params
   if (!dateId || !slug) {
-    throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'KICKSTART_NO_PARAMS', step: 'details', origin: { field: 'slug|dateId', received: { slug, dateId } }, message: 'slug et dateId requis' })
   }
 
   const body = await readBody(event)
   const { email, firstname, lastname, phone, isoContact, title, stage, currency, owner } = body
 
   if (!email || !title) {
-    throw createError({ statusCode: 400, statusMessage: 'email et title requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'KICKSTART_MISSING_FIELDS', step: 'details', origin: { field: !email ? 'email' : 'title', received: !email ? email ?? null : title ?? null }, message: 'email et title requis' })
   }
 
   console.log(`[kickstart] START slug=${slug} dateId=${dateId} email=${email}`)
@@ -26,7 +26,7 @@ export default defineEventHandler(async (event) => {
     .eq('travel_slug', slug)
     .single()
   if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
+    throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'KICKSTART_DATE_NOT_FOUND', step: 'details', origin: { field: 'dateId', received: dateId }, message: 'Date introuvable pour ce slug' })
   }
   lap('travel_date validated')
 
@@ -38,7 +38,7 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     console.error('[kickstart] createMinimalDeal failed', err)
-    throw createError({ statusCode: 500, statusMessage: 'Erreur lors de la création du deal' })
+    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'KICKSTART_CREATE_DEAL_FAILED', step: 'details', origin: { endpoint: 'activecampaign.createMinimalDeal' }, message: 'Erreur lors de la création du deal' })
   }
 
   // 3. Insert into booked_dates (booked_places=0 — not counted as reserved until payment)
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
     .single()
   if (bookedError) {
     console.error('[kickstart] Supabase insert failed', bookedError.message)
-    throw createError({ statusCode: 500, statusMessage: bookedError.message })
+    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'KICKSTART_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.insert' }, message: bookedError.message })
   }
   lap(`booked_dates inserted bookedId=${bookedDate.id}`)
 

--- a/server/api/v1/booking/booked_date/option.post.js
+++ b/server/api/v1/booking/booked_date/option.post.js
@@ -3,10 +3,10 @@ import { defineEventHandler, readBody, createError } from 'h3'
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   if (!body?.id) {
-    throw createError({ statusCode: 400, statusMessage: 'id requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'OPTION_NO_ID', step: 'option_booking', origin: { field: 'id', received: null }, message: 'id requis' })
   }
   if (body.booked_places === undefined || body.booked_places === null) {
-    throw createError({ statusCode: 400, statusMessage: 'booked_places requis' })
+    throw funnelReporter.funnelCreateError({ statusCode: 400, code: 'OPTION_NO_BOOKED_PLACES', step: 'option_booking', origin: { field: 'booked_places', received: body.booked_places ?? null }, message: 'booked_places requis' })
   }
 
   // Check if the date is already booked
@@ -16,10 +16,12 @@ export default defineEventHandler(async (event) => {
     .eq('id', body.id)
     .single()
   if (bookedDateError || !bookedDate) {
-    throw createError({ statusCode: 404, statusMessage: bookedDateError?.message || 'Réservation introuvable' })
+    throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'OPTION_BOOKED_DATE_NOT_FOUND', step: 'option_booking', origin: { field: 'id', received: body.id }, message: bookedDateError?.message || 'Réservation introuvable' })
   }
   if (bookedDate.is_option) {
-    throw createError({ statusCode: 409, statusMessage: 'La date est déjà réservée' })
+    // Expected business case (already-optioned) — tagged so the backstop hook
+    // skips it; the client handles this message explicitly.
+    throw createError({ statusCode: 409, statusMessage: 'La date est déjà réservée', data: { code: 'OPTION_ALREADY_PLACED' } })
   }
   else {
     // Convert badges from string to array if needed

--- a/server/api/v1/booking/date/[dateId].get.js
+++ b/server/api/v1/booking/date/[dateId].get.js
@@ -3,9 +3,12 @@ import { defineEventHandler, createError } from 'h3'
 export default defineEventHandler(async (event) => {
   const { dateId } = event.context.params
   if (!dateId) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'dateId requis',
+      code: 'DATE_NO_ID',
+      step: 'init',
+      origin: { field: 'dateId', received: null },
+      message: 'dateId requis',
     })
   }
   const { data, error } = await supabase
@@ -15,9 +18,12 @@ export default defineEventHandler(async (event) => {
     .single()
 
   if (error || !data) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 404,
-      statusMessage: 'Date introuvable',
+      code: 'DATE_NOT_FOUND',
+      step: 'init',
+      origin: { field: 'dateId', received: dateId, endpoint: `/booking/date/${dateId}` },
+      message: error?.message || 'Date introuvable',
     })
   }
   return data

--- a/server/api/v1/chapka/quote.post.ts
+++ b/server/api/v1/chapka/quote.post.ts
@@ -9,9 +9,12 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeInsuranceQ
   }
   const parsedBody = await readValidatedBody(event, body => InsuranceSchema.safeParse(body))
   if (!parsedBody.success) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      message: `Validation failed: ${parsedBody.error.message}`,
+      code: 'INSURANCE_ZOD_VALIDATION',
+      step: 'insurances',
+      origin: funnelReporter.zodToOrigin(parsedBody.error),
+      message: `Validation du devis assurance échouée — ${funnelReporter.zodIssuesSummary(parsedBody.error)}`,
     })
   }
   try {
@@ -22,9 +25,12 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeInsuranceQ
   }
   catch (err) {
     console.error('Error Chapka quote:', err)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 500,
-      message: 'Error Chapka quote',
+      code: 'CHAPKA_QUOTE_FAILED',
+      step: 'insurances',
+      origin: { endpoint: '/chapka/quote' },
+      message: 'Erreur lors de l\'appel Chapka (devis assurance)',
     })
   }
 })

--- a/server/api/v1/monitoring/funnel-error.post.js
+++ b/server/api/v1/monitoring/funnel-error.post.js
@@ -1,0 +1,26 @@
+// Client-facing sink for funnel errors. The browser composable posts a
+// structured FunnelError here; we enrich it server-side and hand it to the
+// reporter. This endpoint must never throw back to the client — a failed report
+// must not surface a second error inside the funnel.
+export default defineEventHandler(async (event) => {
+  try {
+    const body = await readBody(event)
+
+    const enriched = {
+      ...body,
+      source: 'client',
+      occurredAt: body?.occurredAt || new Date().toISOString(),
+      context: {
+        ...(body?.context || {}),
+        url: body?.context?.url || getRequestHeader(event, 'referer') || undefined,
+      },
+    }
+
+    await funnelReporter.reportFunnelError(enriched)
+    return { ok: true }
+  }
+  catch (err) {
+    console.warn('[funnel-error sink] failed to process report:', err?.message || err)
+    return { ok: false }
+  }
+})

--- a/server/api/v1/stripe/index.post.js
+++ b/server/api/v1/stripe/index.post.js
@@ -10,9 +10,12 @@ export default defineEventHandler(async (event) => {
     .single()
 
   if (error) {
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 400,
-      statusMessage: 'Error getting deal from booked_dates',
+      code: 'STRIPE_BOOKED_DATE_NOT_FOUND',
+      step: 'payment',
+      origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
+      message: 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   const deal_id = data.deal_id
@@ -32,9 +35,12 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     console.error('create checkout session error:', err)
-    throw createError({
+    throw funnelReporter.funnelCreateError({
       statusCode: 500,
-      message: 'Failed to create checkout session',
+      code: 'STRIPE_SESSION_CREATE_FAILED',
+      step: 'payment',
+      origin: { endpoint: 'stripe.createCheckoutSession', statusCode: 500 },
+      message: `Échec de création de la session Stripe (dealId=${deal_id}, type=${body?.paymentType})`,
     })
   }
 })

--- a/server/plugins/funnelErrorHook.ts
+++ b/server/plugins/funnelErrorHook.ts
@@ -1,0 +1,41 @@
+// Belt-and-suspenders backstop: any error thrown on a funnel-relevant route
+// that was NOT already instrumented (no structured `data.code` from
+// funnelCreateError) is reported as an unexpected server escape. Instrumented
+// errors are skipped here because the funnel client reports them with full
+// context (URL, dealId, precise field).
+const FUNNEL_ROUTE_PREFIXES = [
+  '/api/v1/ac',
+  '/api/v1/booking',
+  '/api/v1/stripe',
+  '/api/v1/alma',
+  '/api/v1/chapka',
+  '/api/v1/insurance',
+  '/api/v1/checkout',
+]
+
+const isFunnelRoute = (path: string) =>
+  FUNNEL_ROUTE_PREFIXES.some(prefix => path.startsWith(prefix))
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('error', async (error: any, ctx: any) => {
+    try {
+      const path = ctx?.event?.path || ''
+      if (!isFunnelRoute(path)) return
+      // Already instrumented (funnelCreateError) → the client reports it.
+      if (error?.data?.code) return
+
+      await funnelReporter.reportFunnelError({
+        code: 'UNHANDLED_SERVER_ERROR',
+        step: 'unknown',
+        source: 'server',
+        severity: 'fatal',
+        origin: { endpoint: path, statusCode: error?.statusCode },
+        message: error?.statusMessage || error?.message || 'Unhandled server error',
+        raw: { name: error?.name, message: error?.message, stack: error?.stack },
+      })
+    }
+    catch (hookErr: any) {
+      console.warn('[funnelErrorHook] failed:', hookErr?.message || hookErr)
+    }
+  })
+})

--- a/server/utils/funnelReporter.js
+++ b/server/utils/funnelReporter.js
@@ -1,0 +1,194 @@
+import axios from 'axios'
+import { FunnelErrorSchema } from './types/funnelError'
+
+// Central sink for every checkout-funnel error. Receives a structured
+// FunnelError (from the client composable or directly from a server endpoint),
+// normalises it, and fans it out to the configured transports.
+//
+// INVARIANT: reporting must never break the funnel. Every transport runs in its
+// own try/catch and `reportFunnelError` never throws.
+
+const config = useRuntimeConfig()
+const isDev = config.public.environment !== 'production'
+
+const AC_DEAL_BASE = 'https://odysway90522.activehosted.com/app/deals'
+
+// ---- Helpers ---------------------------------------------------------------
+
+// Turn a Zod error into a precise origin: the exact failing field, what was
+// expected and what was received.
+const zodToOrigin = (zodError) => {
+  const issue = zodError?.issues?.[0]
+  if (!issue) return {}
+  return {
+    field: Array.isArray(issue.path) ? issue.path.join('.') : undefined,
+    expected: issue.expected ? String(issue.expected) : issue.message,
+    received: issue.received,
+  }
+}
+
+// Build a human one-liner listing every failing field (used when multiple
+// issues exist), e.g. "currency, value".
+const zodIssuesSummary = (zodError) => {
+  if (!zodError?.issues?.length) return ''
+  return zodError.issues
+    .map(i => `${(i.path || []).join('.') || '(root)'}: ${i.message}`)
+    .join(' | ')
+}
+
+const maskEmail = (email) => {
+  if (typeof email !== 'string' || !email.includes('@')) return email
+  const [local, domain] = email.split('@')
+  const head = local.slice(0, 2)
+  return `${head}${'*'.repeat(Math.max(local.length - 2, 1))}@${domain}`
+}
+
+const redact = (funnelError) => {
+  const clone = JSON.parse(JSON.stringify(funnelError ?? {}))
+  if (clone.context?.email) clone.context.email = maskEmail(clone.context.email)
+  return clone
+}
+
+const truncate = (value, max = 800) => {
+  if (value == null) return ''
+  const str = typeof value === 'string' ? value : JSON.stringify(value)
+  return str.length > max ? `${str.slice(0, max)}…` : str
+}
+
+const stringifyReceived = (received) => {
+  if (received === undefined) return undefined
+  if (received === null) return 'null'
+  return typeof received === 'object' ? truncate(received, 300) : String(received)
+}
+
+// ---- Slack Block Kit formatting -------------------------------------------
+
+const severityEmoji = {
+  fatal: ':rotating_light:',
+  error: ':red_circle:',
+  warning: ':warning:',
+}
+
+const formatBlockKit = (funnelError) => {
+  const { code, step, origin = {}, message, context = {}, severity = 'error', raw } = funnelError
+  const emoji = severityEmoji[severity] || ':red_circle:'
+
+  const lines = []
+  lines.push(`${emoji} *Erreur funnel* — \`${code}\``)
+  lines.push(`*Étape:* ${step}  ·  *Sévérité:* ${severity}`)
+
+  // PRECISE origin — always names the culpable field when known.
+  const originParts = []
+  if (origin.field) originParts.push(`champ \`${origin.field}\``)
+  if (origin.received !== undefined) originParts.push(`reçu \`${stringifyReceived(origin.received)}\``)
+  if (origin.expected) originParts.push(`attendu \`${origin.expected}\``)
+  if (origin.endpoint) originParts.push(`endpoint \`${origin.endpoint}\``)
+  if (origin.statusCode) originParts.push(`status \`${origin.statusCode}\``)
+  lines.push(`*Origine:* ${originParts.length ? originParts.join(' · ') : '—'}`)
+
+  if (message) lines.push(`*Détail:* ${message}`)
+
+  // URL of origin + deal link are first-class lines (explicit user requirement).
+  lines.push(`*URL:* ${context.url || '—'}`)
+  lines.push(context.dealId
+    ? `*Deal:* <${AC_DEAL_BASE}/${context.dealId}|${context.dealId}>`
+    : '*Deal:* —')
+
+  const ctxParts = []
+  if (context.bookedId) ctxParts.push(`bookedId \`${context.bookedId}\``)
+  if (context.email) ctxParts.push(`email \`${context.email}\``)
+  if (context.voyageSlug) ctxParts.push(`voyage \`${context.voyageSlug}\``)
+  if (context.dateId) ctxParts.push(`dateId \`${context.dateId}\``)
+  if (ctxParts.length) lines.push(`*Contexte:* ${ctxParts.join(' · ')}`)
+
+  const rawText = raw?.message || raw?.data
+  if (rawText) lines.push(`*Raw:* ${truncate(rawText)}`)
+
+  return {
+    blocks: [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: lines.join('\n') },
+      },
+    ],
+  }
+}
+
+// ---- Transports ------------------------------------------------------------
+
+const consoleTransport = (funnelError) => {
+  console.error('[funnel-error]', JSON.stringify(funnelError))
+}
+
+// Sends to a dedicated Slack channel. No-op until SLACK_URL_FUNNEL_ERRORS is
+// set, so the feature is safely inert until the webhook is configured.
+const slackTransport = async (funnelError) => {
+  const url = process.env.SLACK_URL_FUNNEL_ERRORS
+  if (!url) return
+  await axios({
+    url,
+    method: 'post',
+    data: formatBlockKit(funnelError),
+  })
+}
+
+const transports = [consoleTransport, slackTransport]
+
+// ---- Public API ------------------------------------------------------------
+
+// Build an H3 error that carries a precise, structured funnel origin in `data`.
+// The funnel client reads `err.data` to produce a single Slack report enriched
+// with its own context (URL, dealId). Because the error is tagged with a
+// `code`, the Nitro backstop hook knows it's already instrumented and skips it.
+const funnelCreateError = ({ statusCode = 400, code, step = 'unknown', origin = {}, message }) => {
+  return createError({
+    statusCode,
+    statusMessage: message,
+    message,
+    data: { funnel: true, code, step, origin, statusCode },
+  })
+}
+
+const reportFunnelError = async (input) => {
+  let funnelError
+  const parsed = FunnelErrorSchema.safeParse(input)
+  if (parsed.success) {
+    funnelError = parsed.data
+  }
+  else {
+    // Never drop a report just because it drifted from the schema.
+    funnelError = {
+      code: 'MALFORMED_REPORT',
+      step: 'unknown',
+      origin: zodToOrigin(parsed.error),
+      message: `Malformed funnel error report: ${zodIssuesSummary(parsed.error)}`,
+      context: {},
+      severity: 'warning',
+      raw: { data: truncate(input, 1000) },
+      source: input?.source === 'server' ? 'server' : 'client',
+    }
+  }
+
+  if (!funnelError.occurredAt) funnelError.occurredAt = new Date().toISOString()
+
+  const redacted = redact(funnelError)
+  await Promise.all(transports.map(async (transport) => {
+    try {
+      await transport(redacted)
+    }
+    catch (transportErr) {
+      console.warn('[funnel-error] transport failed:', transportErr?.message || transportErr)
+    }
+  }))
+
+  return funnelError
+}
+
+export default {
+  reportFunnelError,
+  funnelCreateError,
+  zodToOrigin,
+  zodIssuesSummary,
+  formatBlockKit,
+  isDev,
+}

--- a/server/utils/types/funnelError.ts
+++ b/server/utils/types/funnelError.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+// Shared shape for every error reported from the checkout funnel.
+// Used both as runtime validation at the sink (`reportFunnelError`) and as the
+// single source of truth for the structure the client composable mirrors.
+
+export const FunnelStepSchema = z.enum([
+  'init',
+  'details',
+  'voyage',
+  'travelers',
+  'options',
+  'insurances',
+  'payment',
+  'option_booking',
+  'unknown',
+])
+
+// The PRECISE origin of the problem — which field, what was expected, what was
+// actually received, which endpoint failed and with what status.
+export const FunnelOriginSchema = z.object({
+  field: z.string().optional(),
+  expected: z.string().optional(),
+  received: z.unknown().optional(),
+  endpoint: z.string().optional(),
+  statusCode: z.number().optional(),
+}).partial()
+
+export const FunnelContextSchema = z.object({
+  dealId: z.union([z.string(), z.number()]).optional(),
+  bookedId: z.union([z.string(), z.number()]).optional(),
+  dateId: z.string().optional(),
+  voyageSlug: z.string().optional(),
+  email: z.string().optional(),
+  type: z.string().optional(),
+  url: z.string().optional(),
+}).partial()
+
+export const FunnelRawSchema = z.object({
+  name: z.string().optional(),
+  message: z.string().optional(),
+  stack: z.string().optional(),
+  data: z.unknown().optional(),
+}).partial()
+
+export const FunnelErrorSchema = z.object({
+  code: z.string(),
+  step: FunnelStepSchema.default('unknown'),
+  origin: FunnelOriginSchema.default({}),
+  message: z.string(),
+  context: FunnelContextSchema.default({}),
+  severity: z.enum(['warning', 'error', 'fatal']).default('error'),
+  raw: FunnelRawSchema.optional(),
+  source: z.enum(['client', 'server']).default('client'),
+  occurredAt: z.string().optional(),
+})
+
+export type FunnelStep = z.infer<typeof FunnelStepSchema>
+export type FunnelError = z.infer<typeof FunnelErrorSchema>


### PR DESCRIPTION
## Contexte
Capture toute erreur du funnel de checkout, à n'importe quelle étape, avec son origine racine précise (champ manquant, null, donnée invalide, appel API en échec) — URL d'origine et dealId systématiques — vers Slack (SLACK_URL_FUNNEL_ERRORS) + snackbar utilisateur.

## Ce qui change
**Infra** : funnelError.ts (shape Zod partagée), funnelReporter.js (reportFunnelError/funnelCreateError/zodToOrigin/Block Kit, transports console+slack, ne throw jamais), sink /monitoring/funnel-error, filet Nitro funnelErrorHook.ts, composables useFunnelReporter + useSnackbar + AppSnackbar.vue.
**Couverture** : filet global (apiRequest __funnel, onErrorCaptured, catches useStepperDeal) ; étapes client (init, Détails par champ dont iso, Voyageurs, Assurances, Paiement) ; endpoints serveur avec codes distincts + origine Zod (ac/deals, update-with-bms, deal-from-bms, booking/date, kickstart, assign-deal, option, stripe, alma, chapka).
**Admin** : FunnelErrorTester.vue (panneau flottant admin/dev) ; exemple.env documente SLACK_URL_FUNNEL_ERRORS.

## Anti-doublon
funnelCreateError n'envoie pas sur Slack : l'origine voyage dans data, le client produit un seul message avec URL+dealId. Le filet Nitro ignore les erreurs taggées et ne tire que sur l'imprévu (UNHANDLED_SERVER_ERROR).

## Tests (dev server local)
Sink {ok:true} + console/Slack OK ; DATE_NOT_FOUND (field dateId) ; ZOD_VALIDATION (field currency) ; MISSING_QUERY_PARAMS en SSR ; parse esbuild OK partout.

## À noter
Renseigner SLACK_URL_FUNNEL_ERRORS dans .env. npm run lint cassé sur le repo (config flat @stylistic) → validation via dev server. ASSIGN_DUPLICATE*/OPTION_ALREADY_PLACED taggés sans alerte.
