### PR TITLE
feat(home): dynamic "Dernières places" from Supabase

### DIFF
--- a/app/composables/useLastMinuteVoyages.js
+++ b/app/composables/useLastMinuteVoyages.js
@@ -1,0 +1,21 @@
+import { computed } from 'vue'
+
+// Fetches the "Dernières places" voyages: those whose next bookable departure is
+// the closest in time and still has seats left (one entry per voyage). Client-only
+// + lazy like the other homepage carousels so it never blocks SSR.
+export function useLastMinuteVoyages(limit = 12) {
+  const { data } = useAsyncData(
+    'last-minute-voyages',
+    () => $fetch('/api/v1/booking/last-minute-voyages', { params: { limit } }),
+    {
+      server: false,
+      lazy: true,
+      immediate: true,
+      dedupe: 'defer',
+    },
+  )
+
+  const lastMinuteVoyages = computed(() => data.value || [])
+
+  return { lastMinuteVoyages }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -298,8 +298,7 @@ const homeQuery = groq`
     lastMinute{
       title,
       eyebrow,
-      subtitle,
-      voyages[]->{ ${voyageProjection} }
+      subtitle
     },
     bestSellers{
       eyebrow,
@@ -421,14 +420,10 @@ const heroSubtitleText = computed(() => {
   return portableTextToPlain(blocks)
 })
 
-// Dernières places / Best-sellers reuse curated CMS lists. If the dedicated
-// fields are empty, fall back to existing carousels so the sections still
-// render without new data entry.
-const lastMinuteVoyages = computed(() => {
-  const dedicated = homeSanity.value?.lastMinute?.voyages
-  if (dedicated?.length) return dedicated
-  return homeSanity.value?.summerTravel?.voyagesSummerTravel || []
-})
+// Dernières places: the voyages whose next bookable departure is the closest in
+// time and still has seats left, resolved live from Supabase (one entry per
+// voyage). Title/eyebrow/subtitle stay editable in Sanity.
+const { lastMinuteVoyages } = useLastMinuteVoyages()
 const lastMinuteTitle = computed(() => homeSanity.value?.lastMinute?.title || 'Dernières places')
 const lastMinuteEyebrow = computed(() => homeSanity.value?.lastMinute?.eyebrow || '')
 const lastMinuteSubtitle = computed(() => homeSanity.value?.lastMinute?.subtitle || 'Il reste quelques places, le départ est proche.')

--- a/server/api/v1/booking/last-minute-voyages.get.js
+++ b/server/api/v1/booking/last-minute-voyages.get.js
@@ -1,0 +1,105 @@
+import { defineEventHandler, getQuery } from 'h3'
+import dayjs from 'dayjs'
+import { createClient } from '@sanity/client'
+
+// Same projection the homepage uses for its curated carousels so the returned
+// voyages render identically in VoyageCardWithDates.
+const voyageProjection = `
+  _id,
+  "slug": slug.current,
+  image,
+  imageCard,
+  rating,
+  comments,
+  title,
+  availabilityTypes,
+  duration,
+  pricing,
+  closingDays,
+  destinations[]->{ _id, title },
+  experienceType->{ _id, title },
+  categories[]->{ _id, title },
+  monthlyAvailability
+`
+
+// "Dernières places" carousel: instead of a hand-picked Sanity list, surface the
+// voyages whose next bookable departure is the closest in time and still has
+// seats left. Each voyage appears only once (its soonest qualifying date).
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const { limit } = getQuery(event)
+  const maxVoyages = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : 12
+
+  const sanityClient = createClient({
+    projectId: config.public.sanity.projectId,
+    dataset: config.public.sanity.dataset,
+    apiVersion: config.public.sanity.apiVersion,
+    useCdn: false,
+  })
+
+  // 1. Pull all upcoming published departures, soonest first.
+  const { data: rawDates, error } = await supabase
+    .from('travel_dates')
+    .select('travel_slug, booked_seat, max_travelers, displayed_booked_seat, displayed_max_travelers, custom_display, displayed_status, status, departure_date')
+    .eq('published', true)
+    .eq('is_custom_travel', false)
+    .eq('deleted', false)
+    .eq('is_test', false)
+    .gte('departure_date', new Date().toISOString())
+    .order('departure_date', { ascending: true })
+
+  if (error) {
+    console.error('last-minute-voyages supabase error', error)
+    return []
+  }
+  if (!rawDates?.length) return []
+
+  // Seats left, honouring the displayed_* overrides when custom_display is on.
+  const hasSeatsLeft = (d) => {
+    const useDisplayed = d.custom_display
+    const max = useDisplayed ? d.displayed_max_travelers : d.max_travelers
+    const booked = useDisplayed ? d.displayed_booked_seat : d.booked_seat
+    // No known cap -> treat as bookable rather than hiding it.
+    if (max == null) return true
+    return Number(max) - Number(booked || 0) > 0
+  }
+
+  // Explicitly "Complet" dates are never last-minute candidates.
+  const isFull = d => d.displayed_status === 'full' || d.status === 'full'
+
+  const candidates = rawDates.filter(d => d.travel_slug && !isFull(d) && hasSeatsLeft(d))
+  if (!candidates.length) return []
+
+  // 2. Resolve closingDays (and confirm existence) for the candidate voyages.
+  const candidateSlugs = [...new Set(candidates.map(d => d.travel_slug))]
+  const sanityVoyages = await sanityClient.fetch(
+    `*[_type == "voyage" && slug.current in $slugs]{ ${voyageProjection} }`,
+    { slugs: candidateSlugs },
+  )
+  if (!sanityVoyages?.length) return []
+
+  const voyageBySlug = sanityVoyages.reduce((acc, v) => {
+    if (v?.slug) acc[v.slug] = v
+    return acc
+  }, {})
+
+  // 3. Keep only bookable dates (departure beyond the voyage's closing window),
+  //    then dedupe to the soonest qualifying date per voyage. rawDates is already
+  //    sorted ascending, so the first hit per slug is the closest one.
+  const now = dayjs()
+  const seen = new Set()
+  const orderedSlugs = []
+
+  for (const d of candidates) {
+    const voyage = voyageBySlug[d.travel_slug]
+    if (!voyage || seen.has(d.travel_slug)) continue
+    const closingDays = Number.isFinite(Number(voyage.closingDays)) ? Number(voyage.closingDays) : 30
+    if (dayjs(d.departure_date).diff(now, 'day') < closingDays) continue
+    seen.add(d.travel_slug)
+    orderedSlugs.push(d.travel_slug)
+    if (orderedSlugs.length >= maxVoyages) break
+  }
+
+  // 4. Return the voyages in soonest-departure order.
+  return orderedSlugs.map(slug => voyageBySlug[slug]).filter(Boolean)
+})


### PR DESCRIPTION
## Summary

The homepage **"Dernières places"** carousel previously showed a hand-picked list of voyages configured in Sanity. This PR makes it fully dynamic: it surfaces the voyages whose **next bookable departure is the closest in time** and **still has seats available**, one entry per voyage.

## How it works

**New endpoint** — `server/api/v1/booking/last-minute-voyages.get.js`
- Pulls upcoming `travel_dates` (`published`, non-custom, not deleted/test, `departure_date >= now`), sorted soonest-first.
- Keeps only dates with **seats left** (`max_travelers − booked_seat > 0`, honouring `displayed_*` values when `custom_display` is on) and drops any flagged `full`.
- Resolves each voyage's `closingDays` from Sanity and excludes dates already inside the closing window, so only genuinely bookable dates surface.
- **Dedupes to one entry per voyage** (soonest qualifying date), returns the matching Sanity voyage docs — using the same projection as the other homepage carousels — ordered by nearest departure. Defaults to 12 voyages (`?limit=`).

**New composable** — `app/composables/useLastMinuteVoyages.js`
- Client-only + lazy fetch, mirroring `useTravelDates`/`useTravelersCount` so it never blocks SSR.

**Homepage** — `app/pages/index.vue`
- Removed the hand-picked `lastMinute.voyages[]` from the GROQ query (kept `title`/`eyebrow`/`subtitle` editable in Sanity).
- Wired the carousel to the composable. Slugs flow into `homeVoyageSlugs` → `useTravelDates`, so each card shows its next departure exactly like the other carousels.

## Verification

- API returns 12 voyages, deduped one-per-slug, ordered by nearest bookable departure, all with seats available.
- Homepage renders 12 lazy card columns in the section — same structure as the working "Départs garantis" carousel — with no console errors from the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)