### PR TITLE
Replace /avis-voyageurs links with Trustpilot

### DIFF
--- a/app/components/content/CommonReviewContainer.vue
+++ b/app/components/content/CommonReviewContainer.vue
@@ -49,7 +49,9 @@
         class="mt-12"
       >
         <v-btn
-          to="/avis-voyageurs"
+          href="https://fr.trustpilot.com/review/odysway.com"
+          target="_blank"
+          rel="noopener noreferrer"
           color="primary"
           height="62"
           size="large"

--- a/app/components/content/HomeReviewsRail.vue
+++ b/app/components/content/HomeReviewsRail.vue
@@ -23,7 +23,9 @@
 
     <div class="d-flex justify-center mt-8">
       <v-btn
-        to="/avis-voyageurs"
+        href="https://fr.trustpilot.com/review/odysway.com"
+        target="_blank"
+        rel="noopener noreferrer"
         color="primary"
         height="60"
         size="large"


### PR DESCRIPTION
## What

Redirects the two clickable review CTA buttons from the internal `/avis-voyageurs` page to the Trustpilot page (https://fr.trustpilot.com/review/odysway.com), opening in a new tab.

- `CommonReviewContainer.vue` — "Afficher plus de témoignages" / homepage CTA button
- `HomeReviewsRail.vue` — "Voir tous les avis" button

Changed `to="/avis-voyageurs"` → `href="https://fr.trustpilot.com/review/odysway.com"` with `target="_blank"` and `rel="noopener noreferrer"`.

## Why

Consolidate traveler reviews on Trustpilot.

## Notes for reviewer

- The `/avis-voyageurs` page itself is **not** removed. It remains reachable directly and is still referenced in the sitemap, `llms.txt`, Sanity revalidation, and analytics tracking. Only the in-app links were repointed. Let me know if the page and those references should also be cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)