### PR TITLE
Redesign destinations page + topbar destinations menu

### DIFF
--- a/app/components/DestinationsMegaMenu.vue
+++ b/app/components/DestinationsMegaMenu.vue
@@ -1,0 +1,180 @@
+<template>
+  <v-menu
+    v-model="open"
+    location="bottom"
+    offset="10"
+    :close-on-content-click="true"
+    transition="fade-transition"
+  >
+    <template #activator="{ props: menuProps }">
+      <button
+        type="button"
+        class="dest-trigger"
+        :class="{ 'dest-trigger--transparent': isTransparent, 'dest-trigger--open': open }"
+        :aria-expanded="open"
+        v-bind="menuProps"
+      >
+        Destinations
+        <v-icon
+          class="dest-trigger__chevron"
+          size="18"
+        >
+          {{ mdiChevronDown }}
+        </v-icon>
+      </button>
+    </template>
+
+    <v-card
+      class="dest-mega"
+      elevation="8"
+      rounded="lg"
+    >
+      <div class="dest-mega__cols">
+        <div
+          v-for="zone in zones"
+          :key="zone.id"
+          class="dest-mega__col"
+        >
+          <h3>
+            <v-icon size="15">
+              {{ mdiMapMarkerOutline }}
+            </v-icon>
+            {{ zone.name }}
+          </h3>
+          <NuxtLink
+            v-for="destination in zone.destinations.slice(0, 6)"
+            :key="destination._id"
+            :to="`/destinations/${destination.slug}`"
+          >
+            {{ destination.title }}
+          </NuxtLink>
+          <NuxtLink
+            class="dest-mega__all"
+            :to="`/destinations/${zone.slug}`"
+          >
+            Voir tout {{ zone.name }} →
+          </NuxtLink>
+        </div>
+      </div>
+      <div class="dest-mega__foot">
+        <p>Pas encore d'idée ? <b>Parcourez tous les voyages</b> et filtrez par envie.</p>
+        <v-btn
+          color="secondary"
+          rounded="pill"
+          class="dest-mega__cta text-none"
+          to="/voyages"
+        >
+          Tous nos voyages
+          <v-icon
+            end
+            size="18"
+          >
+            {{ mdiArrowRight }}
+          </v-icon>
+        </v-btn>
+      </div>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup>
+import { mdiArrowRight, mdiChevronDown, mdiMapMarkerOutline } from '@mdi/js'
+
+defineProps({
+  isTransparent: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const open = ref(false)
+const { zones } = useDestinationsMenu()
+</script>
+
+<style scoped>
+.dest-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 18px;
+  font-weight: 500;
+  color: rgb(43, 76, 82);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.dest-trigger__chevron {
+  color: rgb(43, 76, 82);
+  transition: transform 0.2s ease;
+}
+.dest-trigger--open .dest-trigger__chevron {
+  transform: rotate(180deg);
+}
+.dest-trigger--transparent {
+  color: #fbf0ec;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+}
+.dest-trigger--transparent .dest-trigger__chevron {
+  color: #fbf0ec;
+}
+
+.dest-mega {
+  max-width: 940px;
+  padding: 22px 24px 16px;
+}
+.dest-mega__cols {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(150px, 1fr));
+  gap: 20px;
+}
+.dest-mega__col h3 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #de5e2c;
+}
+.dest-mega__col h3 :deep(.v-icon) {
+  color: inherit;
+}
+.dest-mega__col a {
+  display: block;
+  padding: 5px 0;
+  font-size: 14px;
+  color: #333;
+  text-decoration: none;
+}
+.dest-mega__col a:hover {
+  color: #2b4c52;
+}
+.dest-mega__all {
+  margin-top: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #2b4c52 !important;
+}
+.dest-mega__foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(43, 76, 82, 0.13);
+}
+.dest-mega__foot p {
+  margin: 0;
+  font-size: 13.5px;
+  color: #5d6566;
+}
+.dest-mega__cta {
+  margin-left: auto;
+}
+</style>

--- a/app/components/HeaderOdysway.vue
+++ b/app/components/HeaderOdysway.vue
@@ -67,15 +67,39 @@
           style="width: 150px; height: auto; max-width: 150px;"
         >
       </NuxtLink>
+
+      <nav
+        class="d-header-nav d-none d-md-flex align-center ga-1 ga-lg-2 ml-4 ml-lg-6"
+        aria-label="Navigation principale"
+      >
+        <DestinationsMegaMenu :is-transparent="isTransparent" />
+        <v-btn
+          v-if="header?.button2?.visible"
+          height="45"
+          color="primary"
+          class="text-caption text-md-body-1"
+          :class="isTransparent ? 'filter' : ''"
+          @click="handleButton2Click"
+        >
+          {{ header.button2.text }}
+        </v-btn>
+        <v-btn
+          v-if="header?.button3?.visible"
+          height="45"
+          color="primary"
+          class="text-caption text-md-body-1"
+          :class="isTransparent ? 'filter' : ''"
+          @click="handleButton3Click"
+        >
+          {{ header.button3.text }}
+        </v-btn>
+      </nav>
+
       <v-spacer />
 
       <div
         class="d-flex align-center ga-2 ga-lg-4"
       >
-        <SearchDialogTrigger
-          v-if="route.path !== '/'"
-          :btn-class="isTransparent ? '' : 'test-btn-class'"
-        />
         <v-btn
           v-if="header?.button1?.visible"
           height="45"
@@ -87,36 +111,21 @@
         >
           {{ header.button1.text }}
         </v-btn>
-        <v-btn
-          v-if="header?.button2?.visible"
-          color="primary"
-          height="45"
-          :class="isTransparent ? 'filter' : ''"
-          class="text-caption text-md-body-1 d-none d-md-inline"
-          @click="handleButton2Click"
-        >
-          {{ header.button2.text }}
-        </v-btn>
-        <v-btn
-          v-if="header?.button3?.visible"
-          color="primary"
-          height="45"
-          :class="isTransparent ? 'filter' : 'mr-2'"
-          class="text-caption text-md-body-1 d-none d-md-inline "
-          @click="handleButton3Click"
-        >
-          {{ header.button3.text }}
-        </v-btn>
         <div
           class="d-flex align-center ga-2"
           :class="isTransparent ? '' : 'ml-3'"
         >
+          <SearchDialogTrigger
+            v-if="route.path !== '/'"
+            btn-class=""
+          />
           <v-btn
             v-if="header?.button4?.visible"
             href="tel: +33184807975"
             color="primary"
             height="45"
-            :variant="isTransparent ? 'text' : 'tonal'"
+            rounded="pill"
+            :variant="isTransparent ? 'text' : 'outlined'"
             :class="isTransparent ? 'filter' : ''"
             class="text-caption text-md-body-1 d-none d-md-flex"
             @click="handleButton4Click"
@@ -126,6 +135,7 @@
           <v-btn
             v-if="header?.button5?.visible"
             height="45"
+            rounded="pill"
             :variant="isTransparent ? 'text' : 'tonal'"
             :class="isTransparent ? 'text-soft-blush text-shadow' : 'bg-primary text-white '"
             class="text-caption text-md-body-1 d-none d-md-inline "

--- a/app/components/content/HeaderDrawer.vue
+++ b/app/components/content/HeaderDrawer.vue
@@ -17,10 +17,61 @@
         :style="drawerContentStyle"
       >
         <nav
-          v-if="navigation.length"
+          v-if="navigation.length || zones.length"
           class="drawer-nav"
           aria-label="Navigation mobile"
         >
+          <!-- Destinations : liste des continents -->
+          <div
+            v-if="zones.length"
+            class="drawer-nav__group"
+          >
+            <button
+              type="button"
+              class="drawer-nav__row drawer-nav__acc"
+              :aria-expanded="destOpen"
+              @click="destOpen = !destOpen"
+            >
+              <span>Destinations</span>
+              <v-icon
+                class="drawer-nav__chevron"
+                :class="{ 'drawer-nav__chevron--open': destOpen }"
+                size="22"
+              >
+                {{ mdiChevronDown }}
+              </v-icon>
+            </button>
+            <v-expand-transition>
+              <div
+                v-show="destOpen"
+                class="drawer-nav__sub"
+              >
+                <NuxtLink
+                  v-for="zone in zones"
+                  :key="zone.id"
+                  :to="`/destinations/${zone.slug}`"
+                  class="drawer-nav__sublink"
+                  @click="handleNavigate"
+                >
+                  <span>{{ zone.name }}</span>
+                </NuxtLink>
+                <NuxtLink
+                  to="/destinations"
+                  class="drawer-nav__sublink drawer-nav__sublink--highlight"
+                  @click="handleNavigate"
+                >
+                  <span>Toutes nos destinations</span>
+                  <v-icon
+                    class="drawer-nav__sublink-arrow"
+                    size="18"
+                  >
+                    {{ mdiArrowRight }}
+                  </v-icon>
+                </NuxtLink>
+              </div>
+            </v-expand-transition>
+          </div>
+
           <template
             v-for="(item, i) in navigation"
             :key="i"
@@ -125,7 +176,17 @@ const { header } = defineProps({
 const router = useRouter()
 const route = useRoute()
 
-const navigation = computed(() => header?.navigation ?? [])
+// Drop any CMS "Destinations" nav item: our dedicated continent accordion
+// (below) replaces it with the full destinations list. Strip non-letters first
+// so Sanity stega (invisible zero-width chars appended in dev) can't defeat the
+// match.
+const navigation = computed(() =>
+  (header?.navigation ?? []).filter(item => item?.label?.replace(/[^\p{L}]/gu, '').toLowerCase() !== 'destinations'),
+)
+
+// Destinations continents list, shared with the desktop mega-menu.
+const { zones } = useDestinationsMenu()
+const destOpen = ref(false)
 
 // Which nav panel (Destinations, …) is expanded. Single-open accordion.
 const openIndex = ref(null)

--- a/app/composables/useDestinationsMenu.js
+++ b/app/composables/useDestinationsMenu.js
@@ -1,0 +1,59 @@
+// Shared data source for the destinations landing page and the topbar
+// destinations menu (desktop mega-menu + mobile drawer). Fetches every region
+// with the destinations that reference it, then shapes them into ordered
+// "zones" (continents) each holding its country tiles.
+//
+// Returns `{ zones, asyncData }`:
+//  - `zones`    computed list of continents (ready after the fetch resolves).
+//  - `asyncData` the awaitable useSanityQuery handle; `await asyncData` on a
+//               page blocks SSR so `zones` is populated in the payload.
+// Components that only need the (eventually reactive) list can ignore
+// `asyncData` and never turn into async components.
+const destinationsMenuQuery = groq`*[_type == "region"]{
+  _id,
+  nom,
+  "slug": slug.current,
+  image,
+  "destinations": *[_type == "destination" && references(^._id)] | order(title asc){
+    _id,
+    title,
+    "slug": slug.current,
+    image
+  }
+}`
+
+// Display order for the continents. Regions not listed keep their natural order
+// after the known ones.
+const ZONE_ORDER = [
+  'france',
+  'europe',
+  'asie',
+  'afrique',
+  'amerique-du-sud',
+  'amerique-centrale',
+  'amerique-du-nord',
+  'moyen-orient',
+  'oceanie',
+]
+
+export function useDestinationsMenu() {
+  const asyncData = useSanityQuery(destinationsMenuQuery, {}, { default: () => [] })
+
+  const zones = computed(() => (asyncData.data.value || [])
+    .map(region => ({
+      id: region._id,
+      name: region.nom,
+      slug: region.slug,
+      image: region.image,
+      destinations: (region.destinations || [])
+        .filter(destination => destination.slug && destination.image?.asset?._ref),
+    }))
+    .filter(zone => zone.slug && zone.destinations.length)
+    .sort((a, b) => {
+      const ia = ZONE_ORDER.indexOf(a.slug)
+      const ib = ZONE_ORDER.indexOf(b.slug)
+      return (ia === -1 ? ZONE_ORDER.length : ia) - (ib === -1 ? ZONE_ORDER.length : ib)
+    }))
+
+  return { zones, asyncData }
+}

--- a/app/pages/destinations/index.vue
+++ b/app/pages/destinations/index.vue
@@ -1,77 +1,112 @@
 <template>
-  <ContentLayout
-    type="destinations"
-    :display-divider="true"
-    :displayed-data="displayedData"
-    :page-content="destinationsWithVoyages.pageContent"
-  >
-    <template #content>
-      <DisplayVoyagesRow
-        :voyages="destinationsWithVoyages.destinations"
-      />
-    </template>
-  </ContentLayout>
+  <div class="destinations-page">
+    <!-- ============ INTRO ============ -->
+    <section class="dp-container dp-intro">
+      <h1>{{ pageTitle }}</h1>
+      <p>{{ introText }}</p>
+    </section>
+
+    <!-- ============ CONTINENTS ============ -->
+    <section class="dp-container">
+      <div class="dp-zones">
+        <div
+          v-for="zone in zones"
+          :key="zone.id"
+          class="dp-zone"
+        >
+          <div class="dp-zone__head">
+            <h2>{{ zone.name }}</h2>
+            <NuxtLink :to="`/destinations/${zone.slug}`">
+              Voir tous les voyages {{ prep(zone.name) }}
+              <v-icon size="18">
+                {{ mdiArrowRight }}
+              </v-icon>
+            </NuxtLink>
+          </div>
+          <div class="dp-grid">
+            <NuxtLink
+              v-for="destination in zone.destinations"
+              :key="destination._id"
+              class="dp-tile"
+              :to="`/destinations/${destination.slug}`"
+            >
+              <img
+                class="dp-tile__ph"
+                :src="getImageUrl(destination.image?.asset?._ref, null, null, 600)"
+                :alt="destination.title"
+                loading="lazy"
+                decoding="async"
+              >
+              <span class="dp-tile__scrim" />
+              <span class="dp-tile__name">{{ destination.title }}</span>
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ SEO ============ -->
+    <section class="dp-seo-band">
+      <div class="dp-container dp-seo">
+        <h2>Nos destinations, vécues de l'intérieur</h2>
+        <p>
+          Toutes nos destinations s'organisent autour d'une même idée : vivre un lieu de
+          l'intérieur, à la table des familles et au pas des guides qui le connaissent par cœur.
+          En <NuxtLink to="/destinations/france">
+            France
+          </NuxtLink>, des Alpes à la Bretagne. En
+          <NuxtLink to="/destinations/europe">
+            Europe
+          </NuxtLink>, des volcans des Açores aux nuits
+          étoilées de Laponie. En <NuxtLink to="/destinations/asie">
+            Asie
+          </NuxtLink>, du Népal au Japon, de
+          village en village.
+        </p>
+        <p>
+          En <NuxtLink to="/destinations/afrique">
+            Afrique
+          </NuxtLink>, du Sahara marocain aux plaines de
+          Tanzanie. Dans les <NuxtLink to="/destinations/amerique-du-sud">
+            Amériques
+          </NuxtLink>, des chemins
+          incas du Pérou à l'Amazonie brésilienne. Quelle que soit la destination, nos voyages en
+          immersion se vivent en petit groupe de 8 voyageurs maximum ou en privatisé, à votre
+          rythme, dans le respect des lieux et des personnes.
+        </p>
+      </div>
+    </section>
+  </div>
 </template>
 
 <script setup>
-const allQueries = `
-{
-  "destinations": *[_type == "destination"]{
-    _id,
-    title,
-    slug,
-    "description": metaDescription,
-    image,
-    "voyages": *[_type == "voyage" && references(^._id) && !('custom' in availabilityTypes)]{
-      _id,
-      title,
-      "slug": slug.current,
-      image,
-      imageCard,
-      duration,
-      nights,
-      rating,
-      comments,
-      availabilityTypes,
-      "startingPrice": pricing.startingPrice,
-      pricing {
-        startingPrice
-      },
-      destinations[]->{
-        _id,
-        title
-      },
-      experienceType->{
-        _id,
-        title
-      },
-      categories[]->{
-        _id,
-        title
-      },
-      monthlyAvailability
-    }
-  },
-  "pageContent": *[_type == "page_destinations"][0]{
-    ...
-  }
-}
-`
-const { data: destinationsWithVoyages } = await useSanityQuery(allQueries)
+import { mdiArrowRight } from '@mdi/js'
+import { getImageUrl } from '~/utils/getImageUrl'
 
-const displayedData = computed(() => ({
-  items: destinationsWithVoyages.value?.destinations?.map(destination => ({
-    id: destination._id,
-    title: destination.title,
-    slug: destination.slug?.current,
-    image: destination.image,
-    type: 'destinations',
-    discoveryTitle: destination.metaDescription || destination.description || '',
-  })).filter(destination => destination.image?.asset?._ref),
-  selectedItem: null,
-  pageTitle: destinationsWithVoyages.value?.pageContent?.index?.pageTitle || 'Toutes nos destinations',
-  showOnBottom: false,
-}))
+const { zones, asyncData } = useDestinationsMenu()
+await asyncData
+
+const pageContentQuery = groq`*[_type == "page_destinations"][0]{
+  index,
+  heroText,
+  seo
+}`
+const { data: pageContent } = await useSanityQuery(pageContentQuery)
+
+const pageTitle = computed(() =>
+  pageContent.value?.index?.pageTitle || 'Toutes nos destinations de voyage en immersion',
+)
+
+const introText = computed(() =>
+  pageContent.value?.heroText
+  || `Chez Odysway, chaque destination se découvre pas à pas, au plus près de celles et ceux qui y vivent. De la France aux grands espaces d'Asie, d'Afrique ou des Amériques, vous choisissez une terre et nous vous ouvrons la porte de ses habitants. Nos voyages en immersion, en petit groupe ou en privatisé, prennent le temps de la rencontre et de la marche, loin des sentiers les plus fréquentés.`,
+)
+
+// Grammatical preposition preceding the continent name ("de France", "d'Asie"…).
+function prep(name) {
+  if (!name) return ''
+  return /^[aeiouyàâäéèêëîïôöûü]/i.test(name.trim()) ? `d'${name}` : `de ${name}`
+}
 
 useHead({
   htmlAttrs: {
@@ -79,12 +114,184 @@ useHead({
   },
 })
 
-if (destinationsWithVoyages.value?.pageContent) {
+if (pageContent.value) {
   useSeo({
-    seoData: destinationsWithVoyages.value?.pageContent?.seo,
+    seoData: pageContent.value?.seo,
     slug: 'destinations',
-    content: destinationsWithVoyages.value?.pageContent,
+    content: pageContent.value,
     pageType: 'website',
   })
 }
 </script>
+
+<style scoped>
+.destinations-page {
+  --dp-teal: #2b4c52;
+  --dp-orange: #de5e2c;
+  --dp-ink: #222223;
+  --dp-muted: #5d6566;
+  --dp-surface-alt: #f7f8f8;
+  --dp-border: rgba(43, 76, 82, 0.13);
+  color: var(--dp-ink);
+}
+
+.dp-container {
+  max-width: 1180px;
+  margin-inline: auto;
+  padding-inline: 24px;
+}
+
+/* ===== Intro ===== */
+.dp-intro {
+  margin-top: 34px;
+}
+.dp-intro h1 {
+  margin: 0 0 12px;
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--dp-ink);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+}
+.dp-intro p {
+  max-width: 780px;
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.75;
+  color: var(--dp-muted);
+}
+
+/* ===== Zones (continents) ===== */
+.dp-zones {
+  margin-top: 40px;
+}
+.dp-zone {
+  margin-bottom: 40px;
+}
+.dp-zone:last-child {
+  margin-bottom: 0;
+}
+.dp-zone__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  margin: 0 0 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--dp-border);
+}
+.dp-zone__head h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--dp-teal);
+  letter-spacing: -0.01em;
+}
+.dp-zone__head a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--dp-orange);
+  white-space: nowrap;
+  text-decoration: none;
+  transition: gap 0.2s ease;
+}
+.dp-zone__head a:hover {
+  gap: 9px;
+}
+.dp-zone__head a :deep(.v-icon) {
+  color: inherit;
+}
+
+.dp-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+.dp-tile {
+  position: relative;
+  height: 160px;
+  border-radius: 14px;
+  overflow: hidden;
+  display: block;
+  text-decoration: none;
+  background: var(--dp-surface-alt);
+}
+.dp-tile:hover .dp-tile__ph {
+  transform: scale(1.05);
+}
+.dp-tile__ph {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.35s ease;
+}
+.dp-tile__scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(8, 14, 12, 0.72), rgba(8, 14, 12, 0.05) 60%);
+}
+.dp-tile__name {
+  position: absolute;
+  left: 13px;
+  right: 13px;
+  bottom: 11px;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+}
+
+/* ===== SEO ===== */
+.dp-seo-band {
+  margin-top: 72px;
+  background: var(--dp-surface-alt);
+  padding-block: 3.5rem;
+}
+.dp-seo h2 {
+  margin: 0 0 14px;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--dp-teal);
+}
+.dp-seo p {
+  max-width: 900px;
+  margin: 0 0 14px;
+  font-size: 15px;
+  line-height: 1.8;
+  color: var(--dp-muted);
+}
+.dp-seo p:last-child {
+  margin-bottom: 0;
+}
+.dp-seo a {
+  color: var(--dp-teal);
+  font-weight: 600;
+  text-decoration: none;
+}
+.dp-seo a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 960px) {
+  .dp-intro h1 {
+    font-size: 28px;
+  }
+  .dp-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .dp-zone__head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .dp-seo-band {
+    margin-top: 48px;
+    padding-block: 2.5rem;
+  }
+}
+</style>


### PR DESCRIPTION
## What

Applies the new immersion-travel design to **`/destinations`** and adds a **Destinations menu to the topbar**.

### Destinations page (`app/pages/destinations/index.vue`)
- Intro heading + paragraph, continent **zones** each with a 4-col grid of country tiles (real Sanity images), and an SEO band.
- Replaces the old `ContentLayout` / search-hero layout.
- **No** "Accueil › Destinations" breadcrumb (per request).

### Topbar Destinations menu
- New `useDestinationsMenu` composable — one GROQ query grouping every `region` with its referencing `destination`s into ordered zones (France → Europe → Asie → Afrique → Amériques…). Shared by the page, the desktop mega-menu, and the mobile drawer (single deduped fetch).
- `DestinationsMegaMenu.vue` — desktop dropdown with continent columns, "Voir tout {continent}" links, and a "Tous nos voyages" CTA.
- `HeaderDrawer.vue` — mobile drawer gets a single Destinations accordion listing the continents + "Toutes nos destinations". Filters out the duplicate CMS "Destinations" nav item (match strips invisible Sanity stega chars).

### Header polish (`HeaderOdysway.vue`)
- Group **Destinations / Prochains départs / L'esprit Odysway** next to the logo, all sharing the same teal type (18px / 500).
- Move the **search icon** next to the phone.
- **Phone** → outlined pill; **phone + Prendre RDV** → pill-rounded, matching the prototype.

## Why
Ships the redesigned destinations experience and makes destinations reachable from the topbar on desktop and mobile.

## Verified
Ran the dev server and checked in-browser: page renders 8 continents / 61 tiles with images, desktop mega-menu opens with 8 columns, mobile accordion shows the continents (no duplicate), and the header cluster matches the prototype. No console errors.

## Reviewer notes
- **"Voyages" is hidden in dev only**: there's a *draft* of the header config (`drafts.header-configuration`) with `button1` (Voyages) `visible: false`. Dev reads drafts, so it's hidden locally; the **published** header has it visible, so it renders in production. No code change needed.
- Zone ordering keys off region slugs (`france`, `europe`, `asie`, `amerique-du-sud`, …); regions with an unknown slug still render, sorted last.
- The invisible characters visible when inspecting text are Sanity's dev-only stega encoding (disabled in production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)