### PR TITLE
fix(seo): resolve Google Search Console structured-data errors

### DIFF
--- a/app/pages/avis-voyageurs.vue
+++ b/app/pages/avis-voyageurs.vue
@@ -48,15 +48,14 @@ const reviewsQuery = `
 `
 const { data: reviews } = await useSanityQuery(reviewsQuery)
 
-const reviewSchema = computed(() => createReviewAggregateSchema(
+const reviewRating = createReviewAggregateSchema(
   (reviews.value || []).map(r => ({
     author: r.author,
     date: r.date,
     rating: r.rating,
     text: typeof r.text === 'string' ? r.text : '',
-    voyageTitle: r.voyage?.title || '',
   })),
-))
+)
 
 if (page.value) {
   useSeo({
@@ -65,7 +64,18 @@ if (page.value) {
     pageType: 'website',
     slug: 'avis-voyageurs',
     baseUrl: '/avis-voyageurs',
-    structuredData: reviewSchema.value,
   })
+}
+
+// Attach the first-party rating + reviews to the single Organization identity
+// (#identity, emitted globally by nuxt-schema-org) so the brand carries exactly
+// one aggregateRating site-wide instead of a competing raw Organization node.
+if (reviewRating) {
+  useSchemaOrg([
+    defineOrganization({
+      aggregateRating: reviewRating.aggregateRating,
+      review: reviewRating.review,
+    }),
+  ])
 }
 </script>

--- a/app/pages/entreprise.vue
+++ b/app/pages/entreprise.vue
@@ -183,12 +183,6 @@ if (page.value) {
     pageType: 'website',
     slug: 'entreprise',
     baseUrl: '/entreprise',
-    structuredData: [
-      createOrganizationSchema({
-        description: page.value?.seo?.metaDescription || defaultContent.description,
-      }),
-      createWebSiteSchema(),
-    ],
   })
 }
 </script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -587,17 +587,6 @@ if (homeSanity.value) {
     pageType: 'website',
     slug: 'home',
     baseUrl: '/',
-    structuredData: [
-      createOrganizationSchema({
-        description: homeSanity.value.seo?.metaDescription || defaultContent.description,
-        aggregateRating: {
-          ratingValue: '4.9',
-          reviewCount: '156',
-          bestRating: '5',
-        },
-      }),
-      createWebSiteSchema(),
-    ],
   })
 }
 </script>

--- a/app/pages/sur-mesure.vue
+++ b/app/pages/sur-mesure.vue
@@ -65,12 +65,6 @@ if (page.value) {
     pageType: 'website',
     slug: 'sur-mesure',
     baseUrl: '/sur-mesure',
-    structuredData: [
-      createOrganizationSchema({
-        description: page.value?.seo?.metaDescription || defaultContent.description,
-      }),
-      createWebSiteSchema(),
-    ],
   })
 }
 function getButtonLink(link) {

--- a/app/pages/vision-voyage-odysway.vue
+++ b/app/pages/vision-voyage-odysway.vue
@@ -100,12 +100,6 @@ if (visionPage.value) {
     pageType: 'website',
     slug: 'vision-voyage-odysway',
     baseUrl: '/vision-voyage-odysway',
-    structuredData: [
-      createOrganizationSchema({
-        description: visionPage.value?.seo?.metaDescription || defaultContent.description,
-      }),
-      createWebSiteSchema(),
-    ],
   })
 }
 </script>

--- a/app/utils/structuredData.js
+++ b/app/utils/structuredData.js
@@ -4,76 +4,10 @@
 
 import { portableTextToPlain } from './portableTextToPlain'
 
-/**
- * Generate Organization structured data
- * @param {Object} options - Organization options
- * @returns {Object} Organization schema
- */
-export function createOrganizationSchema(options = {}) {
-  const {
-    name = 'Odysway',
-    url = 'https://odysway.com',
-    logo = 'https://odysway.com/logos/logo_noir.png',
-    description = '',
-    sameAs = [
-      'https://www.facebook.com/odysway',
-      'https://www.instagram.com/odysway',
-      'https://www.linkedin.com/company/odysway',
-    ],
-    aggregateRating = null,
-  } = options
-
-  const schema = {
-    '@context': 'https://schema.org',
-    '@type': 'Organization',
-    '@id': `${url}/#organization`,
-    name,
-    url,
-    logo,
-    description,
-    sameAs,
-    'contactPoint': {
-      '@type': 'ContactPoint',
-      'contactType': 'Customer Service',
-      'telephone': '+33-1-84-88-37-91',
-      'email': 'contact@odysway.com',
-      'areaServed': 'FR',
-      'availableLanguage': ['French', 'English'],
-    },
-  }
-
-  // Add aggregate rating if provided
-  if (aggregateRating) {
-    schema.aggregateRating = {
-      '@type': 'AggregateRating',
-      ...aggregateRating,
-    }
-  }
-
-  return schema
-}
-
-/**
- * Generate WebSite structured data with search action
- * @returns {Object} WebSite schema
- */
-export function createWebSiteSchema() {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    '@id': 'https://odysway.com/#website',
-    'name': 'Odysway',
-    'url': 'https://odysway.com',
-    'publisher': {
-      '@id': 'https://odysway.com/#organization',
-    },
-    'potentialAction': {
-      '@type': 'SearchAction',
-      'target': 'https://odysway.com/voyages?q={search_term_string}',
-      'query-input': 'required name=search_term_string',
-    },
-  }
-}
+// Organization + WebSite identity are emitted globally by nuxt-schema-org
+// (schemaOrg.identity in nuxt.config -> #identity / #website). Do NOT create
+// competing Organization/WebSite nodes here; attach page-specific data (e.g.
+// review ratings) to the identity via useSchemaOrg(defineOrganization(...)).
 
 /**
  * Generate BlogPosting structured data
@@ -160,7 +94,13 @@ export function createTouristTripSchema(voyage, url, config = null) {
     schema.itinerary = voyage.programmeBlock.map((day, index) => ({
       '@type': 'TouristAttraction',
       'name': day.title,
-      'description': day.description,
+      // description may be Portable Text (array of blocks); Schema.org expects
+      // a plain string, otherwise Google reports "Invalid object type for field".
+      'description': typeof day.description === 'string'
+        ? day.description
+        : Array.isArray(day.description)
+          ? portableTextToPlain(day.description)
+          : undefined,
       'image': day.photo
         ? [getImageUrl(day.photo.asset?._ref || day.photo, `${voyage.slug?.current || 'voyage'}-day-${index + 1}.jpg`, config)]
         : undefined,
@@ -221,8 +161,14 @@ export function createReviewAggregateSchema(reviews, opts = {}) {
     orgId = 'https://odysway.com/#identity',
   } = opts
 
+  // Only keep ratings within the [1, maxNote] scale — values outside the range
+  // (e.g. stray 0 or 6 in the CMS) make Google reject the reviewRating as
+  // "out of range" and skew the aggregate.
   const valid = (reviews || []).filter(
-    r => typeof r?.rating === 'number' && (r?.text || '').trim().length > 0,
+    r => typeof r?.rating === 'number'
+      && r.rating >= 1
+      && r.rating <= maxNote
+      && (r?.text || '').trim().length > 0,
   )
   if (valid.length === 0) return null
 
@@ -237,6 +183,7 @@ export function createReviewAggregateSchema(reviews, opts = {}) {
       'reviewRating': {
         '@type': 'Rating',
         'ratingValue': r.rating,
+        'worstRating': 1,
         'bestRating': maxNote,
       },
       'author': {
@@ -245,7 +192,6 @@ export function createReviewAggregateSchema(reviews, opts = {}) {
       },
       ...(r.date ? { datePublished: new Date(r.date).toISOString().split('T')[0] } : {}),
       'reviewBody': r.text.trim(),
-      ...(r.voyageTitle ? { name: r.voyageTitle } : {}),
     }))
 
   return {
@@ -256,6 +202,7 @@ export function createReviewAggregateSchema(reviews, opts = {}) {
     'aggregateRating': {
       '@type': 'AggregateRating',
       'ratingValue': Math.round(average * 10) / 10,
+      'worstRating': 1,
       'bestRating': maxNote,
       'ratingCount': valid.length,
       'reviewCount': valid.length,


### PR DESCRIPTION
## Contexte

Google Search Console remontait trois erreurs de résultats enrichis (données structurées Schema.org) :

1. **`/avis-voyageurs` — « La note se situe en dehors de la plage » (`reviewRating`)** : la base CMS contient des notes hors échelle 1–5 (vérifié sur le dataset live : **2 avis à `0`, 1 avis à `6`** sur 460), et `worstRating` n'était jamais déclaré.
2. **Pages voyage — « Type d'objet non valide pour le champ `<parent_node>` »** (ex. `voyage-ours-roumanie`, `immersion-observatoire-astronomique`) : les `itinerary[].description` étaient injectées en **Portable Text** (tableau d'objets `block`) là où Schema.org attend une chaîne.
3. **`/avis-voyageurs` — « L'avis contient plusieurs notes cumulées »** : deux `aggregateRating` concurrents décrivaient la même entité Odysway — une note **codée en dur** sur la homepage (`4.9`/`156`) vs la vraie note calculée sur `#identity`.

## Changements

**Corrections d'erreurs**
- `createReviewAggregateSchema` : filtrage des notes à `[1, maxNote]` (recalcule la moyenne sur ce sous-ensemble) + ajout de `worstRating` sur chaque `Rating` et l'`AggregateRating`.
- `createTouristTripSchema` : conversion des descriptions d'itinéraire via `portableTextToPlain` (les `string` déjà valides sont conservées).
- Suppression de l'`aggregateRating` fabriqué de la homepage → une seule note cumulée (réelle) sur tout le site.

**Consolidation de l'identité Schema.org**
- `nuxt-schema-org` émet déjà `Organization #identity` et `WebSite #website` globalement. Les helpers manuels `createOrganizationSchema`/`createWebSiteSchema` étaient redondants et fragmentaient l'entité (`#organization` vs `#identity`) → suppression des fonctions et de leurs appels (`index`, `entreprise`, `vision-voyage-odysway`, `sur-mesure`).
- La note + les avis fusionnent désormais dans le nœud unique `#identity` via `useSchemaOrg([defineOrganization({ aggregateRating, review })])`, même pattern que `faq.vue`.

## Vérification

- Fonctions pures retestées avec données réelles : notes 0/6/null exclues, moyenne 4.5, `worst/bestRating` présents, descriptions d'itinéraire toutes en `string`.
- `node --check` OK, aucune référence orpheline aux fonctions supprimées.
- ⚠️ Le serveur de dev ne démarre pas dans le worktree (module `sanity` désynchronisé, problème d'env connu), donc pas de rendu SSR live vérifié ici. **À contrôler côté preview/déploiement** avec le [test des résultats enrichis Google](https://search.google.com/test/rich-results) sur `/`, `/avis-voyageurs` et une page voyage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)