### PR TITLE
fix(destinations,home): full-width menu, voyage-filtered destinations & card tweaks

### DIFF
--- a/app/components/DestinationsMegaMenu.vue
+++ b/app/components/DestinationsMegaMenu.vue
@@ -5,6 +5,8 @@
     offset="10"
     :close-on-content-click="true"
     transition="fade-transition"
+    scroll-strategy="close"
+    content-class="dest-mega-menu"
   >
     <template #activator="{ props: menuProps }">
       <button
@@ -27,51 +29,53 @@
     <v-card
       class="dest-mega"
       elevation="8"
-      rounded="lg"
+      rounded="0"
     >
-      <div class="dest-mega__cols">
-        <div
-          v-for="zone in zones"
-          :key="zone.id"
-          class="dest-mega__col"
-        >
-          <h3>
-            <v-icon size="15">
-              {{ mdiMapMarkerOutline }}
-            </v-icon>
-            {{ zone.name }}
-          </h3>
-          <NuxtLink
-            v-for="destination in zone.destinations.slice(0, 6)"
-            :key="destination._id"
-            :to="`/destinations/${destination.slug}`"
+      <div class="dest-mega__inner">
+        <div class="dest-mega__cols">
+          <div
+            v-for="zone in zones"
+            :key="zone.id"
+            class="dest-mega__col"
           >
-            {{ destination.title }}
-          </NuxtLink>
-          <NuxtLink
-            class="dest-mega__all"
-            :to="`/destinations/${zone.slug}`"
-          >
-            Voir tout {{ zone.name }} →
-          </NuxtLink>
+            <h3>
+              <v-icon size="15">
+                {{ mdiMapMarkerOutline }}
+              </v-icon>
+              {{ zone.name }}
+            </h3>
+            <NuxtLink
+              v-for="destination in zone.destinations.slice(0, 6)"
+              :key="destination._id"
+              :to="`/destinations/${destination.slug}`"
+            >
+              {{ destination.title }}
+            </NuxtLink>
+            <NuxtLink
+              class="dest-mega__all"
+              :to="`/destinations/${zone.slug}`"
+            >
+              Voir tout {{ zone.name }} →
+            </NuxtLink>
+          </div>
         </div>
-      </div>
-      <div class="dest-mega__foot">
-        <p>Pas encore d'idée ? <b>Parcourez tous les voyages</b> et filtrez par envie.</p>
-        <v-btn
-          color="secondary"
-          rounded="pill"
-          class="dest-mega__cta text-none"
-          to="/voyages"
-        >
-          Tous nos voyages
-          <v-icon
-            end
-            size="18"
+        <div class="dest-mega__foot">
+          <p>Pas encore d'idée ? <b>Parcourez toutes nos destinations</b> et laissez-vous inspirer.</p>
+          <v-btn
+            color="secondary"
+            rounded="pill"
+            class="dest-mega__cta text-none"
+            to="/destinations"
           >
-            {{ mdiArrowRight }}
-          </v-icon>
-        </v-btn>
+            Toutes nos destinations
+            <v-icon
+              end
+              size="18"
+            >
+              {{ mdiArrowRight }}
+            </v-icon>
+          </v-btn>
+        </div>
       </div>
     </v-card>
   </v-menu>
@@ -122,8 +126,13 @@ const { zones } = useDestinationsMenu()
 }
 
 .dest-mega {
-  max-width: 940px;
-  padding: 22px 24px 16px;
+  width: 100vw;
+  border-top: 1px solid rgba(43, 76, 82, 0.13);
+}
+.dest-mega__inner {
+  max-width: 1180px;
+  margin-inline: auto;
+  padding: 26px 24px 18px;
 }
 .dest-mega__cols {
   display: grid;
@@ -176,5 +185,18 @@ const { zones } = useDestinationsMenu()
 }
 .dest-mega__cta {
   margin-left: auto;
+}
+</style>
+
+<!-- Non-scoped: the v-menu content is teleported to the overlay root, so the
+     full-width positioning override can't live in the scoped block. Vuetify
+     anchors the content to the activator with inline left/max-width; force it
+     to span the viewport instead (the inner wrapper re-centers the content). -->
+<style>
+.dest-mega-menu {
+  left: 0 !important;
+  right: 0 !important;
+  max-width: 100vw !important;
+  width: 100vw !important;
 }
 </style>

--- a/app/components/DisplayVoyagesRow.vue
+++ b/app/components/DisplayVoyagesRow.vue
@@ -194,8 +194,8 @@ const voyagesWithCta = computed(() => {
   const result = [...original]
   const cta = { id: 'cta', isCta: true }
 
-  if (original.length >= 2) {
-    result.splice(2, 0, cta)
+  if (original.length >= 5) {
+    result.splice(5, 0, cta)
   }
   else {
     result.push(cta)

--- a/app/components/content/NextDepartureCard.vue
+++ b/app/components/content/NextDepartureCard.vue
@@ -180,7 +180,7 @@
 </template>
 
 <script setup>
-import { IconArrowRight, IconUsers, IconCalendarCheck, IconCircleCheck, IconFlame } from '@tabler/icons-vue'
+import { IconArrowRight, IconUsers, IconCalendarCheck, IconFlame } from '@tabler/icons-vue'
 import { mdiArrowRight, mdiAccountMultiple, mdiCalendarCheck } from '@mdi/js'
 import dayjs from 'dayjs'
 import { useImage } from '#imports'
@@ -246,9 +246,9 @@ const daysUntilDeparture = computed(() => {
 })
 
 const topLeftBadge = computed(() => {
-  if (props.variant === 'guaranteed' && isGuaranteed.value) {
-    return { text: 'Garanti', cls: 'depart-tag--guaranteed', icon: IconCircleCheck }
-  }
+  // The "Garanti" badge is intentionally omitted here: on the homepage
+  // "Nos départs garantis" section the label is redundant with the section
+  // title. Only the last-minute "J-X" badge remains.
   if (props.variant === 'lastMinute' && typeof daysUntilDeparture.value === 'number' && daysUntilDeparture.value >= 0) {
     return { text: `J-${daysUntilDeparture.value}`, cls: 'depart-tag--late', icon: IconFlame }
   }

--- a/app/composables/useDestinationsMenu.js
+++ b/app/composables/useDestinationsMenu.js
@@ -14,7 +14,7 @@ const destinationsMenuQuery = groq`*[_type == "region"]{
   nom,
   "slug": slug.current,
   image,
-  "destinations": *[_type == "destination" && references(^._id)] | order(title asc){
+  "destinations": *[_type == "destination" && references(^._id) && count(*[_type == "voyage" && references(^._id) && !('custom' in availabilityTypes)]) > 0] | order(title asc){
     _id,
     title,
     "slug": slug.current,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -90,7 +90,6 @@
             <LazyHorizontalCarousel
               text-color="primary"
               slider-name="home-last-minute"
-              :icon="IconFlame"
               :eyebrow="lastMinuteEyebrow"
               :subtitle="lastMinuteSubtitle"
             >
@@ -260,7 +259,6 @@
 </template>
 
 <script setup>
-import { IconFlame } from '@tabler/icons-vue'
 import { portableTextToPlain } from '~/utils/portableTextToPlain'
 
 const config = useRuntimeConfig()


### PR DESCRIPTION
## What & why

Follow-up corrections on the destinations menu, the homepage, and the voyages list.

### Destinations mega-menu (`DestinationsMegaMenu.vue`)
- **Full-width**: the menu now spans the full viewport width (`100vw`) with a centered `max-width: 1180px` inner wrapper, matching the prototype instead of the old capped `940px` card.
- **Close on scroll**: added `scroll-strategy="close"` so the menu dismisses when the user scrolls (Vuetify's default `reposition` kept it open and slid it with the page).
- **CTA**: "Tous nos voyages" → **"Toutes nos destinations"**, now linking to `/destinations` (adjoining sentence updated to match).

### Destinations with at least one voyage (`useDestinationsMenu.js`)
- The shared GROQ query now filters destinations to those with `count(*[_type == "voyage" && references(^._id) && !('custom' in availabilityTypes)]) > 0` (same pattern already used in `SearchField.vue`). This composable feeds both the mega-menu and the `/destinations` page, so empty destinations are hidden in both.

### Homepage (`index.vue` + `NextDepartureCard.vue`)
- **"Nos départs garantis"**: removed the green "Garanti" card badge — redundant with the section title.
- **"Dernières places"**: removed the decorative flame icon from the section header. (Per-card functional flame badges on seats/countdown are untouched.)

### Voyages list (`DisplayVoyagesRow.vue`)
- Moved the CTA card from index 2 to index 5 so it appears further down the results.

## Reviewer notes
- The file originally referenced for the "drawer" changes (`DestinationsDrawerContent.vue`) is **orphaned** (not imported anywhere and lacks the "Tous nos voyages" text). The real topbar destinations menu is `DestinationsMegaMenu.vue`, so all menu changes landed there.
- **Not runtime-verified**: the dev server can't boot in this worktree because `cms/sanity.config.ts` imports the `sanity` Studio package, which isn't in `package.json`/`package-lock.json` (pre-existing env issue). Changes are template/CSS/GROQ-only and were reviewed statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)