### PR TITLE
fix(tracking): restore Meta purchase and CB-click events

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -142,6 +142,22 @@ onMounted(() => {
     return
   }
 
+  // Funnel pages load GTM immediately: add_payment_info fires milliseconds
+  // before window.location.href sends the user to Stripe/Alma, and purchase
+  // fires on a page users often leave in a few seconds. Waiting for the
+  // interaction/15s fallback there loses the event entirely. These pages are
+  // not SEO landing pages, so the Lighthouse budget doesn't apply.
+  const isFunnelPage = path => path.startsWith('/checkout') || path.startsWith('/confirmation')
+
+  if (isFunnelPage(route.path)) {
+    loadGtm()
+    return
+  }
+
+  watch(() => route.path, (path) => {
+    if (isFunnelPage(path)) loadGtm()
+  })
+
   // GTM/SST is ~440KB transferred + ~2.9s of script eval. Loading via
   // requestIdleCallback still landed inside the Lighthouse measurement
   // window on slow 4G. Defer until first user interaction OR a long idle

--- a/app/components/Funnel/Steps/PaymentRedirect.vue
+++ b/app/components/Funnel/Steps/PaymentRedirect.vue
@@ -466,8 +466,13 @@ const stripePay = async () => {
         user_phone: model.value.phone,
         user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
       }
-      trackAddPaymentInfo(voyage, model.value, 'stripe', userData)
-      window.location.href = checkoutLink
+      // Redirect from the tracking callback: pushing and navigating in the
+      // same tick unloads the page before the tags fire, which is what made
+      // the Meta CB-click event disappear. The callback is guaranteed to run
+      // (timeout fallback), so the payment flow never waits on analytics.
+      trackAddPaymentInfo(voyage, model.value, 'stripe', userData, () => {
+        window.location.href = checkoutLink
+      })
     }
     else {
       redirectingToStripe.value = false
@@ -531,8 +536,9 @@ const almaPay = async () => {
         user_phone: model.value.phone,
         user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
       }
-      trackAddPaymentInfo(voyage, model.value, 'alma', userData)
-      window.location.href = checkoutLink.url
+      trackAddPaymentInfo(voyage, model.value, 'alma', userData, () => {
+        window.location.href = checkoutLink.url
+      })
     }
     else {
       redirectingToAlma.value = false

--- a/app/composables/useGtmTracking.js
+++ b/app/composables/useGtmTracking.js
@@ -40,12 +40,54 @@ export const useGtmTracking = () => {
 
     const optOut = useCookie('odysway_employee_optout')
     if (optOut.value === '1') {
-      return
+      return false
     }
     if (environment === 'production' && typeof window !== 'undefined' && window.dataLayer) {
       const cleanedData = cleanStegaData(data)
       window.dataLayer.push(cleanedData)
       // console.log('📊 GTM Event:', cleanedData.event || 'data', cleanedData)
+      return true
+    }
+    return false
+  }
+
+  /**
+   * Push an event, then run `onComplete` once GTM has fired its tags.
+   * Use this before a hard navigation (Stripe/Alma redirect): a plain push
+   * followed by `window.location.href` unloads the page before the tags —
+   * and therefore the Meta/GA requests — ever leave the browser.
+   *
+   * `onComplete` runs exactly once: via GTM's eventCallback when the tags
+   * fired, or via the local timeout when GTM is slow, absent, or the push
+   * was skipped (non-production / employee opt-out). The redirect must never
+   * depend on analytics succeeding.
+   *
+   * @param {Object} data - Data object to push to dataLayer
+   * @param {Function} onComplete - Called once, after tags fired or on timeout
+   * @param {number} timeout - Max wait in ms before continuing anyway
+   */
+  const pushToDataLayerAndWait = (data, onComplete, timeout = 1500) => {
+    let completed = false
+    const complete = () => {
+      if (completed) return
+      completed = true
+      onComplete()
+    }
+
+    const timer = setTimeout(complete, timeout)
+
+    const pushed = pushToDataLayer({
+      ...data,
+      eventTimeout: timeout,
+      eventCallback: () => {
+        clearTimeout(timer)
+        complete()
+      },
+    })
+
+    if (!pushed) {
+      clearTimeout(timer)
+      complete()
     }
   }
 
@@ -504,8 +546,12 @@ export const useGtmTracking = () => {
   /**
    * Track add_payment_info - Payment method selected
    * CSV line 446
+   *
+   * @param {Function} [onComplete] - When provided, called once the tags have
+   *   fired (or after a short timeout). Pass it when the caller redirects to
+   *   the payment provider right after, so the event isn't killed by unload.
    */
-  const trackAddPaymentInfo = (voyage, dynamicDealValues, paymentType, userData = {}) => {
+  const trackAddPaymentInfo = (voyage, dynamicDealValues, paymentType, userData = {}, onComplete = null) => {
     pushToDataLayer({
       ecommerce: null,
     })
@@ -515,7 +561,7 @@ export const useGtmTracking = () => {
     const items = buildCheckoutItems(voyage, dynamicDealValues)
     const totalValue = calculateTotalValue(items)
 
-    pushToDataLayer({
+    const dataLayerEvent = {
       event: 'add_payment_info',
       ecommerce: {
         payment_type: paymentType,
@@ -536,7 +582,14 @@ export const useGtmTracking = () => {
         })),
       },
       user_data: userData,
-    })
+    }
+
+    if (onComplete) {
+      pushToDataLayerAndWait(dataLayerEvent, onComplete)
+    }
+    else {
+      pushToDataLayer(dataLayerEvent)
+    }
   }
 
   /**

--- a/server/api/v1/booking/purchase-data.get.js
+++ b/server/api/v1/booking/purchase-data.get.js
@@ -122,6 +122,7 @@ export default defineEventHandler(async (event) => {
     // Find the most recent payment note (starts with "Paiement")
     let transactionId = bookedDate.deal_id
     let paymentType = 'CB'
+    let paymentNotesCount = 0
 
     if (notesResponse?.notes) {
       // Sort notes by date (most recent first)
@@ -129,8 +130,11 @@ export default defineEventHandler(async (event) => {
         return new Date(b.cdate) - new Date(a.cdate)
       })
 
+      const paymentNotes = sortedNotes.filter(note => note.note?.startsWith('Paiement'))
+      paymentNotesCount = paymentNotes.length
+
       // Find first payment note
-      const paymentNote = sortedNotes.find(note => note.note?.startsWith('Paiement'))
+      const paymentNote = paymentNotes[0]
 
       if (paymentNote) {
         // Parse payment note: "Paiement CB - pi_xxx - Name - email - amount"
@@ -144,9 +148,16 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Only track purchase if this is the first payment (alreadyPaid is 0 or null)
-    const alreadyPaid = parseFloat(deal.alreadyPaid) || 0
-    const shouldTrack = alreadyPaid === 0
+    // Only track purchase on the first payment.
+    //
+    // This used to test `alreadyPaid === 0`, but the Stripe/Alma webhook writes
+    // alreadyPaid on the deal before the confirmation page gets here — the
+    // webhook almost always won the race, so shouldTrack was false and the
+    // purchase event never fired. The payment notes are appended one per
+    // payment, so counting them tells us which payment this is regardless of
+    // webhook timing (0 = note not written yet, still the first payment).
+    // Re-fires on refresh are already prevented client-side via sessionStorage.
+    const shouldTrack = paymentNotesCount <= 1
 
     // Build response with all necessary data for GTM tracking
     return {


### PR DESCRIPTION
## Contexte

Les événements **Purchase** et **ClicCb** avaient disparu côté Meta. L'investigation a remonté trois causes indépendantes, toutes corrigées ici.

## Ce qui changeait

### 1. GTM/SST n'était plus chargé au chargement de page — `app/app.vue`

Depuis `23ee3cc0` ("New perf test implementation"), le conteneur SST (~440 Ko, ~2,9 s d'eval) n'est injecté qu'à la première interaction utilisateur ou après un filet de 15 s.

Sur le tunnel c'est trop tard : le clic sur « Régler » déclenche `mousedown` → GTM *commence* à se télécharger à cet instant, et on quitte la page 1 à 3 s plus tard. Sur `/confirmation`, l'utilisateur n'interagit souvent pas et part avant les 15 s.

Le conteneur est désormais chargé immédiatement sur `/checkout` et `/confirmation` (y compris en navigation SPA, via un `watch` sur `route.path`). Partout ailleurs le chargement différé est inchangé — le budget Lighthouse des pages d'atterrissage SEO n'est pas touché.

### 2. Redirection dans le même tick que le push — `useGtmTracking.js`, `PaymentRedirect.vue`

`trackAddPaymentInfo(...)` suivi immédiatement de `window.location.href` : la page se décharge avant que les tags aient pu partir.

Nouveau helper `pushToDataLayerAndWait(data, onComplete, timeout = 1500)` s'appuyant sur `eventCallback` / `eventTimeout` de GTM. `trackAddPaymentInfo` accepte un 5ᵉ paramètre optionnel `onComplete`, et les deux chemins (Stripe et Alma) redirigent depuis ce callback.

**Le paiement ne dépend jamais de l'analytics** : `pushToDataLayer` renvoie maintenant un booléen, et `onComplete` est garanti de s'exécuter exactement une fois — au déclenchement des tags, au timeout de 1,5 s, ou immédiatement si le push est ignoré (hors production, cookie `odysway_employee_optout`).

### 3. Race condition sur `shouldTrack` — `purchase-data.get.js`

Le tracking était conditionné à `deal.alreadyPaid === 0`, mais le webhook Stripe/Alma écrit `alreadyPaid` sur le deal **avant** que la page de confirmation n'interroge l'API (celle-ci enchaîne 4 appels ActiveCampaign). Le webhook gagnait la course quasi systématiquement → `shouldTrack: false` → l'événement purchase ne partait jamais.

On compte désormais les notes « Paiement » du deal (déjà récupérées et triées juste au-dessus) : `paymentNotesCount <= 1`. Indépendant du timing du webhook (`0` = note pas encore écrite, donc toujours un premier paiement), et un solde reste exclu conformément à l'intention d'origine. La dé-duplication au refresh reste assurée par le `sessionStorage` côté client.

## Vérification

Serveur de dev lancé : home page OK, aucune erreur console ni serveur. L'erreur `Missing required query parameters` sur `/checkout` sans query params est préexistante (comportement documenté dans `699ecd1c`), pas une régression.

**Non vérifiable en local** : en dev `environment !== 'production'`, donc GTM ne se charge jamais et le chemin « GTM réellement chargé » n'est pas exerçable — il faudrait un `booked_id` réel et une session Stripe. À valider en preprod avec le Meta Pixel Helper / l'aperçu GTM sur un parcours complet : clic CB puis page de confirmation.

## Points d'attention pour la relecture

- L'hypothèse « ClicCb = tag déclenché sur `add_payment_info` » reste à confirmer dans le conteneur GTM (hors dépôt) — c'est le seul événement lié au clic CB dans le code.
- Le timeout de 1,5 s avant redirection est un compromis : assez pour laisser partir les tags, assez court pour ne pas être perçu par l'utilisateur (le loader `redirectingToStripe` reste affiché).

## Hors périmètre (repéré au passage, non traité)

- `/confirmation` est toujours en `isr: 5 jours` alors que c'est une page pilotée par query params — même classe de bug que celui corrigé pour `/checkout` dans `699ecd1c`.
- La CSP Report-Only ne whiteliste ni `connect.facebook.net` ni `*.facebook.com`. Sans effet aujourd'hui, mais cassera le pixel Meta client-side le jour du passage en enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)