### PR TITLE
Marges BMS : saisons récurrentes, tarif enfant et statut de configuration par année

### DIFF
--- a/app/components/booking/DateMarginCard.vue
+++ b/app/components/booking/DateMarginCard.vue
@@ -174,6 +174,16 @@
                   <span class="text-medium-emphasis">+ Base × pax</span>
                   <span>{{ formatEur((breakdown.base_margin_per_pax || 0) * breakdown.real_pax) }}</span>
                 </div>
+                <div
+                  v-if="breakdown.child_pax > 0"
+                  class="d-flex justify-space-between py-1"
+                >
+                  <span class="text-medium-emphasis">
+                    + &Eacute;cart enfant
+                    <span class="text-caption">({{ breakdown.child_pax }} enfant{{ breakdown.child_pax > 1 ? 's' : '' }} × {{ formatEur(breakdown.child_margin_delta || 0) }})</span>
+                  </span>
+                  <span>{{ formatEur(breakdown.child_margin_total || 0) }}</span>
+                </div>
                 <div class="d-flex justify-space-between py-1">
                   <span class="text-medium-emphasis">+ Marges add. (vol + assurance + extra)</span>
                   <span>{{ formatEur(breakdown.additional_margins) }}</span>
@@ -235,6 +245,20 @@
           <p class="text-body-2 text-medium-emphasis mb-3">
             Ces valeurs prennent la priorité sur le tableau de marge du voyage. Laissez vide pour utiliser les valeurs par défaut.
           </p>
+          <v-alert
+            type="info"
+            density="compact"
+            variant="tonal"
+            class="mb-3 text-body-2"
+          >
+            L'override fixe <strong>un seul tarif par voyageur</strong> pour cette date, identique qu'il y ait 1 ou 10 pax. Pour un tarif qui varie selon la p&eacute;riode <em>et</em> le nombre de pax, configure plut&ocirc;t des saisons dans le
+            <NuxtLink
+              :to="`/booking-management/margins/${slug}`"
+              class="text-primary"
+            >
+              tableau du voyage
+            </NuxtLink>.
+          </v-alert>
           <v-text-field
             v-model.number="overrideForm.margin_override_per_traveler"
             label="Marge par voyageur (€) — override"
@@ -316,12 +340,16 @@ const realMarginExplanation = computed(() => {
 })
 
 const baseMarginSourceLabel = computed(() => {
-  if (!breakdown.value) return ''
-  if (breakdown.value.base_margin_source === 'override') return 'override date'
-  if (breakdown.value.base_margin_source === 'pax') {
-    return breakdown.value.base_margin_source_year
-      ? `tableau pax — saison ${breakdown.value.base_margin_source_year}`
-      : 'tableau pax'
+  const b = breakdown.value
+  if (!b) return ''
+  if (b.base_margin_source === 'override') return 'override date'
+  if (b.base_margin_source === 'pax' || b.base_margin_source === 'pax_season') {
+    // 'pax_season' means a value entered for the matched season; 'pax' means the
+    // season was left blank (or there is none) and the "Défaut" column applied.
+    const parts = ['tableau pax']
+    if (b.season_label) parts.push(b.base_margin_source === 'pax_season' ? b.season_label : `${b.season_label} → défaut`)
+    if (b.base_margin_source_year) parts.push(`saison ${b.base_margin_source_year}`)
+    return parts.join(' — ')
   }
   return ''
 })

--- a/app/components/booking/MarginsConfiguration.vue
+++ b/app/components/booking/MarginsConfiguration.vue
@@ -1,13 +1,56 @@
 <template>
   <div>
     <p class="text-body-2 text-medium-emphasis mb-4">
-      Configurez la marge par voyageur selon le nombre de pax pour chaque voyage (Pattern A). Une marge fixe peut ensuite être surchargée date par date depuis la fiche départ.
+      Les marges se configurent par ann&eacute;e de d&eacute;part. S&eacute;lectionne l'ann&eacute;e pour voir ce qu'il reste &agrave; param&eacute;trer : un voyage pr&ecirc;t pour {{ currentYear }} peut ne rien avoir pour {{ currentYear + 1 }}.
     </p>
+
+    <!-- Year selector -->
+    <div class="d-flex align-center ga-3 mb-4 flex-wrap">
+      <v-btn-toggle
+        v-model="activeYear"
+        color="primary"
+        density="compact"
+        mandatory
+        variant="outlined"
+      >
+        <v-btn
+          v-for="y in availableYears"
+          :key="y"
+          :value="y"
+        >
+          {{ y }}
+        </v-btn>
+      </v-btn-toggle>
+      <v-progress-circular
+        v-if="loading"
+        indeterminate
+        size="20"
+        color="primary"
+      />
+    </div>
 
     <!-- Stats -->
     <v-row class="mb-4">
       <v-col
-        cols="4"
+        cols="6"
+        md="3"
+      >
+        <v-card
+          rounded="lg"
+          class="bo-card bo-stat-card pa-4"
+          elevation="0"
+          style="border-left-color: rgb(var(--v-theme-error));"
+        >
+          <div class="text-h5 font-weight-bold text-error">
+            {{ counts.unconfigured }}
+          </div>
+          <div class="text-caption text-medium-emphasis">
+            Non configur&eacute;s en {{ activeYear }}
+          </div>
+        </v-card>
+      </v-col>
+      <v-col
+        cols="6"
         md="3"
       >
         <v-card
@@ -17,15 +60,15 @@
           style="border-left-color: rgb(var(--v-theme-warning));"
         >
           <div class="text-h5 font-weight-bold text-warning">
-            {{ unconfiguredCount }}
+            {{ counts.partial }}
           </div>
           <div class="text-caption text-medium-emphasis">
-            Non configurés
+            Incomplets
           </div>
         </v-card>
       </v-col>
       <v-col
-        cols="4"
+        cols="6"
         md="3"
       >
         <v-card
@@ -35,15 +78,15 @@
           style="border-left-color: rgb(var(--v-theme-success));"
         >
           <div class="text-h5 font-weight-bold text-success">
-            {{ configuredCount }}
+            {{ counts.configured }}
           </div>
           <div class="text-caption text-medium-emphasis">
-            Configurés
+            Configur&eacute;s
           </div>
         </v-card>
       </v-col>
       <v-col
-        cols="4"
+        cols="6"
         md="3"
       >
         <v-card
@@ -53,10 +96,11 @@
           style="border-left-color: rgb(var(--v-theme-primary));"
         >
           <div class="text-h5 font-weight-bold">
-            {{ voyages.length }}
+            {{ visibleVoyages.length }}
           </div>
           <div class="text-caption text-medium-emphasis">
-            Total voyages
+            Voyages list&eacute;s
+            <span v-if="hideWithoutDates && withoutDatesCount"> · {{ withoutDatesCount }} masqu&eacute;s</span>
           </div>
         </v-card>
       </v-col>
@@ -89,21 +133,43 @@
           label
           size="small"
         >
-          Non configurés
+          Non configur&eacute;s
+        </v-chip>
+        <v-chip
+          value="partial"
+          label
+          size="small"
+        >
+          Incomplets
         </v-chip>
         <v-chip
           value="configured"
           label
           size="small"
         >
-          Configurés
+          Configur&eacute;s
+        </v-chip>
+        <v-chip
+          value="excluded"
+          label
+          size="small"
+        >
+          Exclus
         </v-chip>
       </v-chip-group>
+      <v-spacer />
+      <v-switch
+        v-model="hideWithoutDates"
+        :label="`Masquer les voyages sans départ en ${activeYear}`"
+        color="primary"
+        density="compact"
+        hide-details
+      />
     </div>
 
     <!-- List -->
     <div
-      v-if="loading"
+      v-if="loading && !marginStatus.length"
       class="d-flex justify-center py-12"
     >
       <v-progress-circular
@@ -121,61 +187,89 @@
         class="bo-card mb-2"
         elevation="0"
       >
-        <NuxtLink
-          :to="`/booking-management/margins/${voyage.slug}`"
-          class="d-flex align-center ga-3 pa-3 text-decoration-none"
-          style="color: inherit;"
-        >
-          <v-avatar
-            size="40"
-            rounded="lg"
-            color="grey-lighten-3"
+        <div class="d-flex align-center ga-3 pa-3">
+          <NuxtLink
+            :to="`/booking-management/margins/${voyage.slug}?year=${activeYear}`"
+            class="d-flex align-center ga-3 flex-grow-1 text-decoration-none"
+            style="color: inherit; min-width: 0;"
           >
-            <v-img
-              v-if="voyage.image"
-              :src="voyage.image"
-              cover
-            />
-            <v-icon
-              v-else
-              size="24"
-              color="grey"
+            <v-avatar
+              size="40"
+              rounded="lg"
+              color="grey-lighten-3"
             >
-              {{ mdiImageOff }}
+              <v-img
+                v-if="voyage.image"
+                :src="voyage.image"
+                cover
+              />
+              <v-icon
+                v-else
+                size="24"
+                color="grey"
+              >
+                {{ mdiImageOff }}
+              </v-icon>
+            </v-avatar>
+            <div class="flex-grow-1 text-truncate">
+              <div class="text-body-1 font-weight-bold text-truncate">
+                {{ voyage.title || voyage.slug }}
+              </div>
+              <div class="text-caption text-medium-emphasis">
+                {{ voyage.slug }} · {{ voyage.dates_total }} d&eacute;part{{ voyage.dates_total > 1 ? 's' : '' }} en {{ activeYear }}
+              </div>
+            </div>
+          </NuxtLink>
+
+          <!-- Status -->
+          <v-chip
+            :color="STATUS_META[voyage.status].color"
+            label
+            size="small"
+            variant="tonal"
+            :prepend-icon="STATUS_META[voyage.status].icon"
+          >
+            {{ voyage.status_detail || STATUS_META[voyage.status].label }}
+          </v-chip>
+
+          <!-- Config mode, editable in place -->
+          <v-menu>
+            <template #activator="{ props: menuProps }">
+              <v-chip
+                v-bind="menuProps"
+                label
+                size="small"
+                variant="outlined"
+                :append-icon="mdiMenuDown"
+              >
+                {{ modeLabel(voyage) }}
+              </v-chip>
+            </template>
+            <v-list density="compact">
+              <v-list-item
+                v-for="item in CONFIG_MODE_ITEMS"
+                :key="item.value"
+                :active="voyage.config_mode === item.value"
+                @click="setMode(voyage, item.value)"
+              >
+                <v-list-item-title>{{ item.title }}</v-list-item-title>
+                <v-list-item-subtitle class="text-caption">
+                  {{ item.hint }}
+                </v-list-item-subtitle>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+
+          <NuxtLink
+            :to="`/booking-management/margins/${voyage.slug}?year=${activeYear}`"
+            class="d-flex align-center"
+            style="color: inherit;"
+          >
+            <v-icon size="16">
+              {{ mdiArrowRight }}
             </v-icon>
-          </v-avatar>
-          <div class="flex-grow-1">
-            <div class="text-body-1 font-weight-bold">
-              {{ voyage.title || voyage.slug }}
-            </div>
-            <div class="text-caption text-medium-emphasis">
-              {{ voyage.slug }}
-            </div>
-          </div>
-          <v-chip
-            v-if="voyage.configuredPaxCount > 0"
-            color="success"
-            label
-            size="small"
-            :prepend-icon="mdiCheckCircle"
-          >
-            {{ voyage.configuredPaxCount }} pax configurés
-          </v-chip>
-          <v-chip
-            v-else
-            color="warning"
-            label
-            size="small"
-          >
-            Non configuré
-          </v-chip>
-          <v-icon
-            size="16"
-            class="ml-2"
-          >
-            {{ mdiArrowRight }}
-          </v-icon>
-        </NuxtLink>
+          </NuxtLink>
+        </div>
       </v-card>
 
       <div
@@ -185,68 +279,144 @@
         Aucun voyage correspondant.
       </div>
     </template>
+
+    <v-alert
+      v-if="error"
+      type="error"
+      density="compact"
+      variant="tonal"
+      class="mt-3"
+    >
+      {{ error }}
+    </v-alert>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import { mdiMagnify, mdiArrowRight, mdiCheckCircle, mdiImageOff } from '@mdi/js'
+import { ref, computed, watch, onMounted } from 'vue'
+import { mdiMagnify, mdiArrowRight, mdiCheckCircle, mdiImageOff, mdiAlertCircleOutline, mdiAlertOutline, mdiMinusCircleOutline, mdiMenuDown } from '@mdi/js'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 
 const props = defineProps({
   voyagesList: { type: Array, default: () => [] },
 })
 
+const STATUS_META = {
+  configured: { label: 'Configuré', color: 'success', icon: mdiCheckCircle },
+  partial: { label: 'Incomplet', color: 'warning', icon: mdiAlertOutline },
+  unconfigured: { label: 'Non configuré', color: 'error', icon: mdiAlertCircleOutline },
+  excluded: { label: 'Exclu', color: 'grey', icon: mdiMinusCircleOutline },
+}
+
+const CONFIG_MODE_ITEMS = [
+  { value: 'pax_table', title: 'Tableau PAX', hint: 'Marge par palier de voyageurs' },
+  { value: 'per_date', title: 'Marge fixe / date', hint: 'Override saisi départ par départ' },
+  { value: 'excluded', title: 'Exclu du suivi', hint: 'Jamais compté comme non configuré' },
+]
+
+const currentYear = new Date().getFullYear()
+
 const loading = ref(false)
+const error = ref('')
 const marginStatus = ref([])
+const availableYears = ref([currentYear, currentYear + 1])
+const activeYear = ref(currentYear)
 const search = ref('')
 const filter = ref('all')
+const hideWithoutDates = ref(true)
 
 const fetchAll = async () => {
   loading.value = true
+  error.value = ''
   try {
-    marginStatus.value = await bookingApi.getMarginsStatus()
+    const payload = await bookingApi.getMarginsStatus(activeYear.value)
+    marginStatus.value = payload.voyages || []
+    if (payload.available_years?.length) availableYears.value = payload.available_years
   }
   catch (err) {
-    console.error(getApiErrorMessage(err, 'Erreur chargement des marges'))
+    error.value = getApiErrorMessage(err, 'Erreur chargement des marges')
   }
   finally {
     loading.value = false
   }
 }
 
+// Voyages come from Sanity (the authoritative catalogue); the API only adds the
+// per-year config status. A voyage the API knows nothing about is simply
+// unconfigured with no departure that year.
 const voyages = computed(() => {
-  const statusBySlug = new Map((marginStatus.value || []).map(s => [s.voyage_slug, s]))
+  const statusBySlug = new Map(marginStatus.value.map(s => [s.voyage_slug, s]))
   return (props.voyagesList || [])
     .filter(v => v?.slug)
-    .map(v => ({
-      slug: v.slug,
-      title: v.title,
-      image: v.image?.asset?.url || null,
-      configuredPaxCount: statusBySlug.get(v.slug)?.configured_pax_count || 0,
-    }))
+    .map((v) => {
+      const status = statusBySlug.get(v.slug)
+      return {
+        slug: v.slug,
+        title: v.title,
+        image: v.image?.asset?.url || null,
+        config_mode: status?.config_mode || 'pax_table',
+        season_count: status?.season_count || 0,
+        season_labels: status?.season_labels || [],
+        dates_total: status?.dates_total || 0,
+        dates_with_override: status?.dates_with_override || 0,
+        configured_pax_count: status?.configured_pax_count || 0,
+        status: status?.status || 'unconfigured',
+        status_detail: status?.status_detail || null,
+      }
+    })
 })
 
-const configuredCount = computed(() => voyages.value.filter(v => v.configuredPaxCount > 0).length)
-const unconfiguredCount = computed(() => voyages.value.filter(v => v.configuredPaxCount === 0).length)
+// Voyages without a departure that year are noise when planning the next season,
+// so they are hidden by default but still counted.
+const visibleVoyages = computed(() =>
+  voyages.value.filter(v => !hideWithoutDates.value || v.dates_total > 0),
+)
+
+const withoutDatesCount = computed(() => voyages.value.filter(v => v.dates_total === 0).length)
+
+const counts = computed(() => ({
+  configured: visibleVoyages.value.filter(v => v.status === 'configured').length,
+  partial: visibleVoyages.value.filter(v => v.status === 'partial').length,
+  unconfigured: visibleVoyages.value.filter(v => v.status === 'unconfigured').length,
+  excluded: visibleVoyages.value.filter(v => v.status === 'excluded').length,
+}))
+
+const STATUS_ORDER = { unconfigured: 0, partial: 1, configured: 2, excluded: 3 }
 
 const filteredVoyages = computed(() => {
   const query = search.value?.toLowerCase() || ''
-  return voyages.value
+  return visibleVoyages.value
     .filter((v) => {
       if (query && !v.slug.toLowerCase().includes(query) && !v.title?.toLowerCase().includes(query)) {
         return false
       }
-      if (filter.value === 'unconfigured') return v.configuredPaxCount === 0
-      if (filter.value === 'configured') return v.configuredPaxCount > 0
+      if (filter.value && filter.value !== 'all') return v.status === filter.value
       return true
     })
     .sort((a, b) => {
-      if (a.configuredPaxCount === 0 && b.configuredPaxCount > 0) return -1
-      if (a.configuredPaxCount > 0 && b.configuredPaxCount === 0) return 1
+      const order = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+      if (order !== 0) return order
       return (a.title || a.slug).localeCompare(b.title || b.slug, 'fr')
     })
 })
 
+function modeLabel(voyage) {
+  if (voyage.config_mode === 'per_date') return 'Marge fixe / date'
+  if (voyage.config_mode === 'excluded') return 'Exclu du suivi'
+  return voyage.season_count > 0 ? `PAX × ${voyage.season_count} saisons` : 'Tableau PAX'
+}
+
+async function setMode(voyage, mode) {
+  if (voyage.config_mode === mode) return
+  try {
+    await bookingApi.updateVoyageMarginSettings(voyage.slug, { config_mode: mode })
+    await fetchAll()
+  }
+  catch (err) {
+    error.value = getApiErrorMessage(err, 'Erreur lors du changement de mode.')
+  }
+}
+
+watch(activeYear, fetchAll)
 onMounted(fetchAll)
 </script>

--- a/app/components/booking/MarginsDashboard.vue
+++ b/app/components/booking/MarginsDashboard.vue
@@ -132,7 +132,7 @@
               Voyages avec config marge
             </div>
             <div class="text-h5 font-weight-bold">
-              {{ voyages.filter(v => v.has_pax_config).length }} / {{ voyages.length }}
+              {{ trackedVoyages.filter(v => v.has_pax_config).length }} / {{ trackedVoyages.length }}
             </div>
             <div class="text-caption text-medium-emphasis mt-1">
               Marge réelle calculable sur ces voyages
@@ -232,7 +232,25 @@
                 </td>
                 <td class="text-right">
                   <v-chip
-                    v-if="voyage.has_pax_config"
+                    v-if="voyage.config_mode === 'excluded'"
+                    color="grey"
+                    label
+                    size="x-small"
+                    variant="tonal"
+                  >
+                    Exclu
+                  </v-chip>
+                  <v-chip
+                    v-else-if="voyage.config_mode === 'per_date'"
+                    :color="voyage.totals.configured_dates_count === voyage.totals.total_count ? 'success' : 'warning'"
+                    label
+                    size="x-small"
+                    variant="tonal"
+                  >
+                    {{ voyage.totals.configured_dates_count }} / {{ voyage.totals.total_count }} dates
+                  </v-chip>
+                  <v-chip
+                    v-else-if="voyage.has_pax_config"
                     color="success"
                     label
                     size="x-small"
@@ -391,6 +409,15 @@
                           >
                             override
                           </v-chip>
+                          <v-chip
+                            v-else-if="date.season_label"
+                            :color="date.source === 'pax_season' ? 'primary' : 'grey'"
+                            size="x-small"
+                            label
+                            variant="tonal"
+                          >
+                            {{ date.season_label }}
+                          </v-chip>
                         </td>
                       </tr>
                     </tbody>
@@ -530,6 +557,10 @@ const voyages = computed(() => {
 const orphanCount = computed(() =>
   (data.value.voyages || []).filter(v => !titleBySlug.value.has(v.voyage_slug)).length,
 )
+
+// Voyages explicitly excluded from margin tracking shouldn't drag the
+// "avec config marge" ratio down — they were opted out on purpose.
+const trackedVoyages = computed(() => voyages.value.filter(v => v.config_mode !== 'excluded'))
 
 const filteredSortedVoyages = computed(() => {
   const query = search.value?.toLowerCase() || ''

--- a/app/pages/booking-management/margins/[slug].vue
+++ b/app/pages/booking-management/margins/[slug].vue
@@ -28,10 +28,228 @@
           {{ voyageTitle || slug }}
         </h1>
         <p class="text-body-2 text-medium-emphasis mb-0">
-          Marge par voyageur selon le nombre de pax (Pattern A) et par année. Une date sans marge configurée pour son année hérite automatiquement de l'année la plus proche (pass&eacute;e ou future, l'ann&eacute;e ant&eacute;rieure gagne en cas d'&eacute;galit&eacute;).
+          Marge par voyageur selon le nombre de pax, l'ann&eacute;e de d&eacute;part et &eacute;ventuellement la saison. Une case vide h&eacute;rite de la saison la plus proche configur&eacute;e, puis de la colonne D&eacute;faut.
         </p>
       </v-col>
     </v-row>
+
+    <!-- Réglages du voyage : mode de configuration + écart enfant -->
+    <v-card
+      rounded="lg"
+      class="bo-card mb-4"
+      elevation="0"
+    >
+      <v-card-text>
+        <div class="d-flex align-start ga-6 flex-wrap">
+          <div style="min-width: 280px;">
+            <div class="text-body-2 font-weight-bold mb-1">
+              Mode de configuration
+            </div>
+            <v-select
+              v-model="settingsForm.config_mode"
+              :items="CONFIG_MODE_ITEMS"
+              density="compact"
+              variant="outlined"
+              hide-details
+            />
+            <div class="text-caption text-medium-emphasis mt-1">
+              {{ configModeHint }}
+            </div>
+          </div>
+
+          <div style="min-width: 280px;">
+            <div class="text-body-2 font-weight-bold mb-1">
+              &Eacute;cart de marge enfant
+            </div>
+            <v-text-field
+              v-model.number="settingsForm.child_margin_delta"
+              type="number"
+              suffix="€ / enfant"
+              density="compact"
+              variant="outlined"
+              hide-details
+              clearable
+              placeholder="0"
+            />
+            <div class="text-caption text-medium-emphasis mt-1">
+              Montant <strong>ajout&eacute;</strong> &agrave; la marge adulte pour chaque enfant : l'achat enfant co&ucirc;te moins cher, la marge est donc sup&eacute;rieure. Vide = m&ecirc;me marge qu'un adulte.
+            </div>
+          </div>
+
+          <v-spacer />
+
+          <div class="d-flex align-center ga-2">
+            <span
+              v-if="settingsSaved"
+              class="text-caption text-success"
+            >Enregistr&eacute;</span>
+            <v-btn
+              size="small"
+              color="primary"
+              variant="tonal"
+              :loading="settingsSaving"
+              :disabled="!settingsDirty"
+              @click="saveSettings"
+            >
+              Enregistrer les r&eacute;glages
+            </v-btn>
+          </div>
+        </div>
+
+        <v-alert
+          v-if="settingsError"
+          type="error"
+          density="compact"
+          variant="tonal"
+          class="mt-3"
+        >
+          {{ settingsError }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
+
+    <!-- Saisons récurrentes -->
+    <v-expansion-panels
+      v-model="seasonsPanel"
+      variant="accordion"
+      class="mb-4"
+    >
+      <v-expansion-panel rounded="lg">
+        <v-expansion-panel-title>
+          <div class="d-flex align-center ga-2">
+            <v-icon size="18">
+              {{ mdiCalendarRange }}
+            </v-icon>
+            <span class="text-body-2 font-weight-bold">Saisons</span>
+            <v-chip
+              v-if="seasons.length"
+              size="x-small"
+              label
+              color="primary"
+            >
+              {{ seasons.map(s => s.label).join(' · ') }}
+            </v-chip>
+            <span
+              v-else
+              class="text-caption text-medium-emphasis"
+            >Aucune — un seul tarif toute l'ann&eacute;e</span>
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <p class="text-body-2 text-medium-emphasis mb-3">
+            Les p&eacute;riodes sont <strong>r&eacute;currentes</strong> : d&eacute;finies une fois en jour/mois, elles valent pour toutes les ann&eacute;es. Seuls les montants sont saisis ann&eacute;e par ann&eacute;e. Une saison peut enjamber le 31/12 (ex. 01/10 &rarr; 30/04). Les p&eacute;riodes ne doivent pas se chevaucher.
+          </p>
+
+          <div
+            v-for="(season, index) in seasonsForm"
+            :key="index"
+            class="d-flex align-center ga-2 mb-2 flex-wrap"
+          >
+            <v-text-field
+              v-model="season.label"
+              label="Nom"
+              density="compact"
+              variant="outlined"
+              hide-details
+              style="max-width: 200px;"
+            />
+            <span class="text-caption text-medium-emphasis">du</span>
+            <v-text-field
+              v-model.number="season.start_day"
+              type="number"
+              label="Jour"
+              density="compact"
+              variant="outlined"
+              hide-details
+              min="1"
+              max="31"
+              style="max-width: 90px;"
+            />
+            <v-select
+              v-model="season.start_month"
+              :items="MONTH_ITEMS"
+              label="Mois"
+              density="compact"
+              variant="outlined"
+              hide-details
+              style="max-width: 150px;"
+            />
+            <span class="text-caption text-medium-emphasis">au</span>
+            <v-text-field
+              v-model.number="season.end_day"
+              type="number"
+              label="Jour"
+              density="compact"
+              variant="outlined"
+              hide-details
+              min="1"
+              max="31"
+              style="max-width: 90px;"
+            />
+            <v-select
+              v-model="season.end_month"
+              :items="MONTH_ITEMS"
+              label="Mois"
+              density="compact"
+              variant="outlined"
+              hide-details
+              style="max-width: 150px;"
+            />
+            <v-btn
+              icon
+              size="x-small"
+              color="error"
+              variant="text"
+              @click="seasonsForm.splice(index, 1)"
+            >
+              <v-icon size="16">
+                {{ mdiDelete }}
+              </v-icon>
+            </v-btn>
+          </div>
+
+          <div class="d-flex align-center ga-2 mt-3">
+            <v-btn
+              size="small"
+              variant="tonal"
+              :prepend-icon="mdiPlus"
+              @click="addSeason"
+            >
+              Ajouter une saison
+            </v-btn>
+            <v-spacer />
+            <v-btn
+              size="small"
+              color="primary"
+              :loading="seasonsSaving"
+              :disabled="!seasonsDirty"
+              @click="saveSeasons"
+            >
+              Enregistrer les saisons
+            </v-btn>
+          </div>
+
+          <v-alert
+            v-if="seasonsError"
+            type="error"
+            density="compact"
+            variant="tonal"
+            class="mt-3"
+          >
+            {{ seasonsError }}
+          </v-alert>
+          <v-alert
+            v-if="seasonsForm.length"
+            type="info"
+            density="compact"
+            variant="tonal"
+            class="mt-3"
+          >
+            Supprimer une saison supprime aussi les montants saisis pour cette saison, toutes ann&eacute;es confondues.
+          </v-alert>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
 
     <!-- Year tabs -->
     <div class="d-flex align-center ga-2 mb-3 flex-wrap">
@@ -70,7 +288,7 @@
       </v-btn>
       <v-spacer />
       <div class="text-caption text-medium-emphasis">
-        Saison = année calendaire de la date de départ
+        Saison = ann&eacute;e calendaire de la date de d&eacute;part
       </div>
     </div>
 
@@ -92,91 +310,118 @@
 
         <template v-else>
           <v-alert
-            v-if="hasFallbackRows"
+            v-if="settings.config_mode !== 'pax_table'"
             type="info"
             density="compact"
             variant="tonal"
             class="mb-3"
           >
-            Les paliers vides pour {{ activeYear }} héritent automatiquement de l'année la plus proche configurée (pass&eacute;e ou future). Saisis une valeur pour override la saison.
+            <template v-if="settings.config_mode === 'per_date'">
+              Ce voyage est en mode <strong>marge fixe par date</strong> : la marge se saisit d&eacute;part par d&eacute;part depuis la fiche date. Ce tableau reste utilisable comme filet si un d&eacute;part n'a pas d'override.
+            </template>
+            <template v-else>
+              Ce voyage est <strong>exclu du suivi des marges</strong> : il n'appara&icirc;t plus dans les voyages &agrave; configurer.
+            </template>
           </v-alert>
 
-          <v-table density="comfortable">
-            <thead>
-              <tr>
-                <th>PAX</th>
-                <th>Marge par voyageur (€)</th>
-                <th>Marge totale (€)</th>
-                <th class="text-right">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="row in rows"
-                :key="row.pax"
-              >
-                <td class="font-weight-bold">
-                  {{ row.pax }}
-                </td>
-                <td>
-                  <v-text-field
-                    v-model.number="row.margin_per_traveler"
-                    type="number"
-                    density="compact"
-                    hide-details
-                    variant="outlined"
-                    :placeholder="row.fallback_value !== null ? `Hérité ${row.fallback_year}: ${row.fallback_value} €` : '0'"
-                    style="max-width: 240px;"
-                  />
-                </td>
-                <td class="text-medium-emphasis">
-                  {{ row.margin_per_traveler ? formatEur(Number(row.margin_per_traveler) * row.pax) : '—' }}
-                </td>
-                <td class="text-right">
-                  <v-btn
-                    icon
-                    size="x-small"
-                    color="error"
-                    variant="text"
-                    :disabled="row.margin_per_traveler === null"
-                    @click="removeRow(row.pax)"
+          <v-alert
+            v-if="hasFallbackCells"
+            type="info"
+            density="compact"
+            variant="tonal"
+            class="mb-3"
+          >
+            Les cases vides h&eacute;ritent automatiquement (saison la plus proche configur&eacute;e, puis colonne D&eacute;faut). Saisis une valeur pour surcharger.
+          </v-alert>
+
+          <div class="table-scroll">
+            <v-table density="comfortable">
+              <thead>
+                <tr>
+                  <th>PAX</th>
+                  <th
+                    v-for="col in columns"
+                    :key="col.key"
                   >
-                    <v-icon size="16">
-                      {{ mdiDelete }}
-                    </v-icon>
-                  </v-btn>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <v-text-field
-                    v-model.number="newPax"
-                    type="number"
-                    density="compact"
-                    hide-details
-                    variant="outlined"
-                    placeholder="Ex: 11"
-                    min="1"
-                    style="max-width: 100px;"
-                  />
-                </td>
-                <td colspan="3">
-                  <v-btn
-                    size="small"
-                    color="primary"
-                    variant="tonal"
-                    :prepend-icon="mdiPlus"
-                    :disabled="!newPax || rows.find(r => r.pax === newPax)"
-                    @click="addRow"
+                    {{ col.label }}
+                    <div
+                      v-if="col.hint"
+                      class="text-caption text-medium-emphasis font-weight-regular"
+                    >
+                      {{ col.hint }}
+                    </div>
+                  </th>
+                  <th class="text-right">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="row in rows"
+                  :key="row.pax"
+                >
+                  <td class="font-weight-bold">
+                    {{ row.pax }}
+                  </td>
+                  <td
+                    v-for="col in columns"
+                    :key="col.key"
                   >
-                    Ajouter ce palier pax
-                  </v-btn>
-                </td>
-              </tr>
-            </tbody>
-          </v-table>
+                    <v-text-field
+                      v-model.number="row.values[col.key]"
+                      type="number"
+                      density="compact"
+                      hide-details
+                      variant="outlined"
+                      :placeholder="cellPlaceholder(row.pax, col)"
+                      style="min-width: 170px;"
+                    />
+                  </td>
+                  <td class="text-right">
+                    <v-btn
+                      icon
+                      size="x-small"
+                      color="error"
+                      variant="text"
+                      :disabled="!hasAnyValue(row)"
+                      @click="removeRow(row.pax)"
+                    >
+                      <v-icon size="16">
+                        {{ mdiDelete }}
+                      </v-icon>
+                    </v-btn>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <v-text-field
+                      v-model.number="newPax"
+                      type="number"
+                      density="compact"
+                      hide-details
+                      variant="outlined"
+                      placeholder="Ex: 11"
+                      min="1"
+                      style="max-width: 100px;"
+                    />
+                  </td>
+                  <td :colspan="columns.length + 1">
+                    <v-btn
+                      size="small"
+                      color="primary"
+                      variant="tonal"
+                      :prepend-icon="mdiPlus"
+                      :disabled="!newPax || rows.some(r => r.pax === newPax)"
+                      @click="addRow"
+                    >
+                      Ajouter ce palier pax
+                    </v-btn>
+                  </td>
+                </tr>
+              </tbody>
+            </v-table>
+          </div>
 
           <div class="d-flex align-center justify-end ga-2 mt-4">
             <v-alert
@@ -195,7 +440,7 @@
               variant="tonal"
               class="flex-grow-1"
             >
-              Modifications enregistrées pour la saison {{ activeYear }}.
+              Modifications enregistr&eacute;es pour la saison {{ activeYear }}.
             </v-alert>
             <v-btn
               color="primary"
@@ -213,8 +458,8 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
-import { mdiArrowLeft, mdiDelete, mdiPlus } from '@mdi/js'
+import { ref, reactive, computed, watch, onMounted } from 'vue'
+import { mdiArrowLeft, mdiDelete, mdiPlus, mdiCalendarRange } from '@mdi/js'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 import { formatEur } from '~/utils/formatNumber'
 
@@ -239,16 +484,37 @@ const { data: voyageData } = await useAsyncData(`voyage-${slug}`, () =>
 const voyageTitle = computed(() => voyageData.value?.title)
 const voyageImage = computed(() => voyageData.value?.image?.asset?.url)
 
+const MONTH_ITEMS = [
+  'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+  'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre',
+].map((title, i) => ({ title, value: i + 1 }))
+
+const CONFIG_MODE_ITEMS = [
+  { title: 'Tableau PAX', value: 'pax_table' },
+  { title: 'Marge fixe par date', value: 'per_date' },
+  { title: 'Exclu du suivi', value: 'excluded' },
+]
+
+const CONFIG_MODE_HINTS = {
+  pax_table: 'La marge vient du tableau ci-dessous (pax × année × saison).',
+  per_date: 'La marge est saisie date par date (override). Le voyage n\'est plus compté comme non configuré tant que ses départs ont leur override.',
+  excluded: 'Le voyage sort des listes de configuration et du ratio « avec config marge ».',
+}
+
+const DEFAULT_COLUMN_KEY = 'default'
+const DEFAULT_PAX_RANGE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
 const loading = ref(false)
 const saving = ref(false)
 const saveError = ref('')
 const saveSuccess = ref(false)
 const newPax = ref(null)
 
-const DEFAULT_PAX_RANGE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-// All margin rows for this voyage across all years, fetched once.
+// All margin rows for this voyage across all years and seasons, fetched once.
 const allRows = ref([])
+const seasons = ref([])
+const settings = ref({ config_mode: 'pax_table', child_margin_delta: null })
+
 const currentYear = new Date().getFullYear()
 const activeYear = ref(Number(route.query.year) || currentYear)
 const extraYearTabs = ref([])
@@ -256,10 +522,110 @@ const extraYearTabs = ref([])
 const rows = ref([])
 let initialState = ''
 
-const isDirty = computed(() => JSON.stringify(rows.value) !== initialState)
-const hasFallbackRows = computed(() => rows.value.some(r => r.fallback_value !== null && r.margin_per_traveler === null))
+// --- Settings form ---------------------------------------------------------
 
-// Years available as tabs: years actually configured + current + any extras added by user.
+const settingsForm = reactive({ config_mode: 'pax_table', child_margin_delta: null })
+const settingsSaving = ref(false)
+const settingsSaved = ref(false)
+const settingsError = ref('')
+
+const configModeHint = computed(() => CONFIG_MODE_HINTS[settingsForm.config_mode] || '')
+
+const settingsDirty = computed(() =>
+  settingsForm.config_mode !== settings.value.config_mode
+  || normalizeAmount(settingsForm.child_margin_delta) !== normalizeAmount(settings.value.child_margin_delta),
+)
+
+async function saveSettings() {
+  settingsSaving.value = true
+  settingsError.value = ''
+  try {
+    settings.value = await bookingApi.updateVoyageMarginSettings(slug, {
+      config_mode: settingsForm.config_mode,
+      child_margin_delta: normalizeAmount(settingsForm.child_margin_delta),
+    })
+    settingsSaved.value = true
+    setTimeout(() => { settingsSaved.value = false }, 3000)
+  }
+  catch (err) {
+    settingsError.value = getApiErrorMessage(err, 'Erreur lors de l\'enregistrement des réglages.')
+  }
+  finally {
+    settingsSaving.value = false
+  }
+}
+
+// --- Seasons form ----------------------------------------------------------
+
+const seasonsPanel = ref(undefined)
+const seasonsForm = ref([])
+const seasonsSaving = ref(false)
+const seasonsError = ref('')
+
+const seasonsDirty = computed(() => JSON.stringify(seasonsForm.value) !== seasonsInitial)
+let seasonsInitial = '[]'
+
+function resetSeasonsForm() {
+  seasonsForm.value = seasons.value.map(s => ({
+    id: s.id,
+    label: s.label,
+    start_day: s.start_day,
+    start_month: s.start_month,
+    end_day: s.end_day,
+    end_month: s.end_month,
+  }))
+  seasonsInitial = JSON.stringify(seasonsForm.value)
+}
+
+function addSeason() {
+  seasonsForm.value.push({
+    id: null,
+    label: seasonsForm.value.length ? 'Basse saison' : 'Haute saison',
+    start_day: 1,
+    start_month: 1,
+    end_day: 31,
+    end_month: 12,
+  })
+}
+
+async function saveSeasons() {
+  seasonsSaving.value = true
+  seasonsError.value = ''
+  try {
+    await bookingApi.updateVoyageMarginSeasons(
+      slug,
+      seasonsForm.value.map((s, index) => ({ ...s, sort_order: index })),
+    )
+    await fetchAll()
+  }
+  catch (err) {
+    seasonsError.value = getApiErrorMessage(err, 'Erreur lors de l\'enregistrement des saisons.')
+  }
+  finally {
+    seasonsSaving.value = false
+  }
+}
+
+// --- Margin table ----------------------------------------------------------
+
+function normalizeAmount(value) {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  return Number.isNaN(n) ? null : n
+}
+
+// One column per season, plus the season-less "Défaut" column that acts as the
+// fallback for any season left blank.
+const columns = computed(() => [
+  { key: DEFAULT_COLUMN_KEY, id: null, label: 'Défaut', hint: seasons.value.length ? 'toutes saisons' : null },
+  ...seasons.value.map(s => ({
+    key: s.id,
+    id: s.id,
+    label: s.label,
+    hint: `${s.start_day}/${s.start_month} → ${s.end_day}/${s.end_month}`,
+  })),
+])
+
 const availableYears = computed(() => {
   const set = new Set([currentYear, ...allRows.value.map(r => r.year), ...extraYearTabs.value])
   return Array.from(set).sort((a, b) => a - b)
@@ -275,13 +641,9 @@ function addYearTab(y) {
 const addNextYearTab = () => addYearTab(nextYearSuggestion.value)
 const addPreviousYearTab = () => addYearTab(previousYearSuggestion.value)
 
-// Picks the nearest year for the given pax (excluding activeYear itself).
-// Matches the server-side rule in margins.js::pickNearestYearCandidate
-// (nearest distance, prefer older year on equal distance).
-function pickFallbackForPax(pax) {
-  const candidates = allRows.value.filter(r =>
-    r.pax === pax && r.year !== activeYear.value && r.margin_per_traveler != null,
-  )
+// Matches the server rule in margins.js::pickNearestYearCandidate
+// (nearest distance, prefer the older year on equal distance).
+function pickNearestYear(candidates) {
   if (!candidates.length) return null
   return [...candidates].sort((a, b) => {
     const da = Math.abs(a.year - activeYear.value)
@@ -291,28 +653,72 @@ function pickFallbackForPax(pax) {
   })[0]
 }
 
-// Rebuild visible `rows` whenever activeYear or allRows changes.
+function rowsFor(pax, seasonId, { excludeActiveYear = false } = {}) {
+  return allRows.value.filter(r =>
+    r.pax === pax
+    && (seasonId ? r.season_id === seasonId : !r.season_id)
+    && r.margin_per_traveler !== null && r.margin_per_traveler !== undefined
+    && (!excludeActiveYear || r.year !== activeYear.value),
+  )
+}
+
+/**
+ * What a blank cell will actually resolve to, mirroring resolveBaseFromRows:
+ * 1. the same season in the nearest other year
+ * 2. the Défaut column for this year
+ * 3. the Défaut column in the nearest other year
+ */
+function cellFallback(pax, col) {
+  if (col.id) {
+    const sameSeason = pickNearestYear(rowsFor(pax, col.id, { excludeActiveYear: true }))
+    if (sameSeason) return { value: Number(sameSeason.margin_per_traveler), label: `Hérité ${sameSeason.year}` }
+
+    const defaultThisYear = rowsFor(pax, null).find(r => r.year === activeYear.value)
+    if (defaultThisYear) return { value: Number(defaultThisYear.margin_per_traveler), label: 'Défaut' }
+
+    const defaultOtherYear = pickNearestYear(rowsFor(pax, null, { excludeActiveYear: true }))
+    if (defaultOtherYear) return { value: Number(defaultOtherYear.margin_per_traveler), label: `Défaut ${defaultOtherYear.year}` }
+    return null
+  }
+
+  const nearest = pickNearestYear(rowsFor(pax, null, { excludeActiveYear: true }))
+  return nearest ? { value: Number(nearest.margin_per_traveler), label: `Hérité ${nearest.year}` } : null
+}
+
+function cellPlaceholder(pax, col) {
+  const fallback = cellFallback(pax, col)
+  return fallback ? `${fallback.label} : ${formatEur(fallback.value)}` : '0'
+}
+
+const hasFallbackCells = computed(() =>
+  rows.value.some(row =>
+    columns.value.some(col => row.values[col.key] === null && cellFallback(row.pax, col)),
+  ),
+)
+
+const hasAnyValue = row => columns.value.some(col => normalizeAmount(row.values[col.key]) !== null)
+
+const isDirty = computed(() => JSON.stringify(rows.value) !== initialState)
+
+// Rebuild the visible grid whenever the year, the rows or the seasons change.
 function rebuildRows() {
-  const byPax = new Map(
+  const byKey = new Map(
     allRows.value
       .filter(r => r.year === activeYear.value)
-      .map(r => [r.pax, r.margin_per_traveler]),
+      .map(r => [`${r.pax}:${r.season_id || DEFAULT_COLUMN_KEY}`, r.margin_per_traveler]),
   )
 
-  // Build the merged view: pax 1..10 + any palier > 10 configured in any year.
-  // Set dedup on extraPax handles cross-year duplicates (same palier in 2026 and 2027).
+  // pax 1..10 + any tier > 10 configured in any year/season. The Set dedups
+  // the same tier appearing in several years.
   const extraPax = [...new Set(allRows.value.filter(r => r.pax > 10).map(r => r.pax))]
   const paxRange = [...DEFAULT_PAX_RANGE, ...extraPax].sort((a, b) => a - b)
 
-  rows.value = paxRange.map((pax) => {
-    const fallback = pickFallbackForPax(pax)
-    return {
-      pax,
-      margin_per_traveler: byPax.has(pax) ? byPax.get(pax) : null,
-      fallback_value: fallback ? Number(fallback.margin_per_traveler) : null,
-      fallback_year: fallback?.year ?? null,
-    }
-  })
+  rows.value = paxRange.map(pax => ({
+    pax,
+    values: Object.fromEntries(
+      columns.value.map(col => [col.key, byKey.has(`${pax}:${col.key}`) ? byKey.get(`${pax}:${col.key}`) : null]),
+    ),
+  }))
   initialState = JSON.stringify(rows.value)
 }
 
@@ -321,7 +727,13 @@ const fetchAll = async () => {
   saveError.value = ''
   saveSuccess.value = false
   try {
-    allRows.value = await bookingApi.getVoyageMargin(slug)
+    const payload = await bookingApi.getVoyageMargin(slug)
+    allRows.value = payload.rows || []
+    seasons.value = payload.seasons || []
+    settings.value = payload.settings || { config_mode: 'pax_table', child_margin_delta: null }
+    settingsForm.config_mode = settings.value.config_mode
+    settingsForm.child_margin_delta = settings.value.child_margin_delta
+    resetSeasonsForm()
     rebuildRows()
   }
   catch (err) {
@@ -334,19 +746,17 @@ const fetchAll = async () => {
 
 const addRow = () => {
   if (!newPax.value) return
-  if (rows.value.find(r => r.pax === newPax.value)) return
+  if (rows.value.some(r => r.pax === newPax.value)) return
   rows.value.push({
     pax: Number(newPax.value),
-    margin_per_traveler: null,
-    fallback_value: null,
-    fallback_year: null,
+    values: Object.fromEntries(columns.value.map(col => [col.key, null])),
   })
   rows.value.sort((a, b) => a.pax - b.pax)
   newPax.value = null
 }
 
 const removeRow = async (pax) => {
-  if (!confirm(`Supprimer le palier ${pax} pax pour la saison ${activeYear.value} ?`)) return
+  if (!confirm(`Supprimer le palier ${pax} pax pour la saison ${activeYear.value} (toutes les colonnes) ?`)) return
   try {
     await bookingApi.deleteVoyageMarginRow(slug, pax, activeYear.value)
     await fetchAll()
@@ -356,15 +766,34 @@ const removeRow = async (pax) => {
   }
 }
 
+// Only the cells that actually changed are written: filled/updated cells are
+// upserted per column, cleared cells are deleted so blanking a value really
+// removes it instead of silently keeping the old amount.
 const save = async () => {
   saving.value = true
   saveError.value = ''
   saveSuccess.value = false
   try {
-    const payload = rows.value
-      .filter(r => r.margin_per_traveler !== null && r.margin_per_traveler !== '')
-      .map(r => ({ pax: r.pax, margin_per_traveler: Number(r.margin_per_traveler) }))
-    await bookingApi.updateVoyageMargin(slug, activeYear.value, payload)
+    const before = new Map(JSON.parse(initialState).map(r => [r.pax, r.values]))
+
+    for (const col of columns.value) {
+      const upserts = []
+      const deletions = []
+
+      for (const row of rows.value) {
+        const next = normalizeAmount(row.values[col.key])
+        const previous = normalizeAmount(before.get(row.pax)?.[col.key])
+        if (next === previous) continue
+        if (next === null) deletions.push(row.pax)
+        else upserts.push({ pax: row.pax, margin_per_traveler: next })
+      }
+
+      if (upserts.length) await bookingApi.updateVoyageMargin(slug, activeYear.value, upserts, col.id)
+      for (const pax of deletions) {
+        await bookingApi.deleteVoyageMarginCell(slug, pax, activeYear.value, col.id)
+      }
+    }
+
     await fetchAll()
     saveSuccess.value = true
     setTimeout(() => { saveSuccess.value = false }, 3000)
@@ -377,7 +806,7 @@ const save = async () => {
   }
 }
 
-// Sync URL ?year= when tab changes, and rebuild visible rows.
+// Sync URL ?year= when the tab changes, and rebuild the visible grid.
 watch(activeYear, (y) => {
   router.replace({ query: { ...route.query, year: String(y) } })
   rebuildRows()
@@ -385,3 +814,9 @@ watch(activeYear, (y) => {
 
 onMounted(fetchAll)
 </script>
+
+<style scoped>
+.table-scroll {
+  overflow-x: auto;
+}
+</style>

--- a/app/utils/bookingApi.js
+++ b/app/utils/bookingApi.js
@@ -86,17 +86,39 @@ export const bookingApi = {
   bookingExists: bookedId =>
     apiRequest(`/booking/booking-exists${encodeQuery({ booked_id: bookedId })}`),
 
-  // Margins — voyage-level PAX table (Pattern A)
-  getMarginsStatus: () => apiRequest('/booking/margins'),
+  // Margins — voyage-level PAX table (Pattern A), declined per year and per season
+  // Status is year-scoped: pass the departure year being configured.
+  getMarginsStatus: (year = null) =>
+    apiRequest(`/booking/margins${encodeQuery(year ? { year } : {})}`),
   getMarginsDashboard: (params = {}) => apiRequest(`/booking/margins/dashboard${encodeQuery(params)}`),
   getMarginsDashboardVoyage: (slug, params = {}) =>
     apiRequest(`/booking/margins/dashboard/${encodeURIComponent(slug)}${encodeQuery(params)}`),
+  // Returns { rows, seasons, settings } — everything the editor needs in one call.
   getVoyageMargin: (slug, year = null) =>
     apiRequest(`/booking/margins/${encodeURIComponent(slug)}${encodeQuery(year ? { year } : {})}`),
-  updateVoyageMargin: (slug, year, rows) =>
-    apiRequest(`/booking/margins/${encodeURIComponent(slug)}${encodeQuery({ year })}`, 'put', rows),
+  // seasonId null targets the "toutes saisons" default rows.
+  updateVoyageMargin: (slug, year, rows, seasonId = null) =>
+    apiRequest(
+      `/booking/margins/${encodeURIComponent(slug)}${encodeQuery(seasonId ? { year, season_id: seasonId } : { year })}`,
+      'put',
+      rows,
+    ),
+  // Removes the whole pax tier for the year — every season plus the default row.
   deleteVoyageMarginRow: (slug, pax, year) =>
     apiRequest(`/booking/margins/${encodeURIComponent(slug)}${encodeQuery({ pax, year })}`, 'delete'),
+  // Removes a single cell. seasonId null targets the "toutes saisons" default row.
+  deleteVoyageMarginCell: (slug, pax, year, seasonId = null) =>
+    apiRequest(
+      `/booking/margins/${encodeURIComponent(slug)}${encodeQuery(
+        seasonId ? { pax, year, scope: 'cell', season_id: seasonId } : { pax, year, scope: 'cell' },
+      )}`,
+      'delete',
+    ),
+  // Recurring DD/MM seasons — replace-all, the payload is the complete list.
+  updateVoyageMarginSeasons: (slug, seasons) =>
+    apiRequest(`/booking/margins/${encodeURIComponent(slug)}/seasons`, 'put', seasons),
+  updateVoyageMarginSettings: (slug, payload) =>
+    apiRequest(`/booking/margins/${encodeURIComponent(slug)}/settings`, 'put', payload),
 
   // Margins — per-date computation + override (Pattern B)
   getDateMargin: (slug, dateId) =>

--- a/server/api/v1/booking/margins/[slug].delete.js
+++ b/server/api/v1/booking/margins/[slug].delete.js
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug requis' })
   }
 
-  const { pax, year } = getQuery(event)
+  const { pax, year, season_id: seasonId, scope } = getQuery(event)
   if (!pax) {
     throw createError({ statusCode: 400, statusMessage: 'pax requis (query param)' })
   }
@@ -18,12 +18,22 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'year requis (query param)' })
   }
 
-  const { error } = await supabase
+  // scope=cell removes a single cell — the given season, or the season-less
+  // default row when season_id is omitted. The default scope removes the whole
+  // pax tier for the year (every season + the default), which is what the
+  // editor's row trash icon means by "supprimer le palier".
+  let query = supabase
     .from('voyage_margins')
     .delete()
     .eq('voyage_slug', slug)
     .eq('pax', Number(pax))
     .eq('year', Number(year))
+
+  if (scope === 'cell') {
+    query = seasonId ? query.eq('season_id', seasonId) : query.is('season_id', null)
+  }
+
+  const { error } = await query
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message })

--- a/server/api/v1/booking/margins/[slug].get.js
+++ b/server/api/v1/booking/margins/[slug].get.js
@@ -13,9 +13,16 @@ export default defineEventHandler(async (event) => {
   const { year } = getQuery(event)
   const yearNum = year ? Number(year) : null
 
+  // The editor needs all three to render a year: the pax rows, the recurring
+  // seasons that become columns, and the voyage settings (mode + child delta).
+  // Returned together so the page loads in a single request.
   try {
-    const rows = await margins.getMarginForVoyage(slug, yearNum)
-    return rows
+    const [rows, seasons, settings] = await Promise.all([
+      margins.getMarginForVoyage(slug, yearNum),
+      margins.getSeasonsForVoyage(slug),
+      margins.getSettingsForVoyage(slug),
+    ])
+    return { rows, seasons, settings }
   }
   catch (err) {
     throw createError({ statusCode: 500, statusMessage: err.message })

--- a/server/api/v1/booking/margins/[slug].put.js
+++ b/server/api/v1/booking/margins/[slug].put.js
@@ -16,13 +16,17 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Body doit être un tableau de { pax, margin_per_traveler }' })
   }
 
-  const year = Number(getQuery(event).year)
+  const query = getQuery(event)
+  const year = Number(query.year)
   if (!year || Number.isNaN(year)) {
     throw createError({ statusCode: 400, statusMessage: 'year requis (query ?year=2026)' })
   }
 
+  // No season_id targets the "toutes saisons" default rows.
+  const seasonId = query.season_id || null
+
   try {
-    const data = await margins.upsertMarginForVoyage(slug, rows, bookingUser?.email, year)
+    const data = await margins.upsertMarginForVoyage(slug, rows, bookingUser?.email, year, seasonId)
     return data
   }
   catch (err) {

--- a/server/api/v1/booking/margins/[slug]/seasons.put.js
+++ b/server/api/v1/booking/margins/[slug]/seasons.put.js
@@ -1,0 +1,35 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+
+// Replace-all: the editor sends the voyage's complete season list.
+// Seasons dropped from the payload are deleted, cascading to their voyage_margins
+// rows — amounts attached to a removed period have no meaning left.
+//
+// Overlap and DD/MM validity are enforced in margins.replaceSeasonsForVoyage,
+// which tags those errors with statusCode 400.
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { slug } = event.context.params
+  if (!slug) {
+    throw createError({ statusCode: 400, statusMessage: 'slug requis' })
+  }
+
+  const body = await readBody(event)
+  const seasons = Array.isArray(body) ? body : body?.seasons
+  if (!Array.isArray(seasons)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Body doit être un tableau de { label, start_month, start_day, end_month, end_day }',
+    })
+  }
+
+  try {
+    return await margins.replaceSeasonsForVoyage(slug, seasons, bookingUser?.email)
+  }
+  catch (err) {
+    throw createError({ statusCode: err.statusCode || 500, statusMessage: err.message })
+  }
+})

--- a/server/api/v1/booking/margins/[slug]/settings.put.js
+++ b/server/api/v1/booking/margins/[slug]/settings.put.js
@@ -1,0 +1,24 @@
+import { defineEventHandler, readBody, createError } from 'h3'
+
+// Per-voyage margin settings: how the voyage is configured (pax table / per-date
+// override / excluded from tracking) and the child margin delta.
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { slug } = event.context.params
+  if (!slug) {
+    throw createError({ statusCode: 400, statusMessage: 'slug requis' })
+  }
+
+  const body = await readBody(event) || {}
+
+  try {
+    return await margins.upsertSettingsForVoyage(slug, body, bookingUser?.email)
+  }
+  catch (err) {
+    throw createError({ statusCode: err.statusCode || 500, statusMessage: err.message })
+  }
+})

--- a/server/api/v1/booking/margins/dashboard.get.js
+++ b/server/api/v1/booking/margins/dashboard.get.js
@@ -13,20 +13,7 @@ const chunk = (arr, size) => {
   return out
 }
 
-// PostgREST caps responses at 1000 rows by default — loop with .range() until short page.
-const fetchAllPaginated = async (buildQuery, pageSize = 1000) => {
-  const out = []
-  for (let page = 0; ; page++) {
-    const from = page * pageSize
-    const to = from + pageSize - 1
-    const { data, error } = await buildQuery().range(from, to)
-    if (error) throw error
-    if (!data?.length) break
-    out.push(...data)
-    if (data.length < pageSize) break
-  }
-  return out
-}
+// `fetchAllPaginated` is auto-imported from server/utils/supabase.js.
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -37,13 +24,14 @@ export default defineEventHandler(async (event) => {
   const dateFrom = from || dayjs().subtract(12, 'month').format('YYYY-MM-DD')
   const dateTo = to || dayjs().add(18, 'month').format('YYYY-MM-DD')
 
-  // 1) Travel dates in window — treat NULL deleted/is_test as false (default).
+  // 1) Travel dates in window — deleted/is_test sont NOT NULL depuis la migration
+  //    soft delete, donc .eq(false) est exact (et matche les index partiels).
   const travelDates = await fetchAllPaginated(() =>
     supabase
       .from('travel_dates')
       .select('id, travel_slug, departure_date, return_date, margin_override_per_traveler')
-      .not('deleted', 'is', true)
-      .not('is_test', 'is', true)
+      .eq('deleted', false)
+      .eq('is_test', false)
       .gte('departure_date', dateFrom)
       .lte('departure_date', dateTo),
   )
@@ -61,6 +49,7 @@ export default defineEventHandler(async (event) => {
           .from('booked_dates')
           .select('travel_date_id, deal_id, booked_places')
           .in('travel_date_id', ids)
+          .eq('deleted', false)
           .gt('booked_places', 0),
       ),
     ),
@@ -77,11 +66,15 @@ export default defineEventHandler(async (event) => {
   )
   const dealsById = new Map(allPaidDeals.map(d => [Number(d.id), d]))
 
-  // 4) Voyage margins config — just need to know which slugs have at least one PAX row.
-  const { data: voyageMarginRows } = await supabase
-    .from('voyage_margins')
-    .select('voyage_slug')
+  // 4) Voyage margin config — which slugs have at least one PAX row, plus the
+  //    declared config mode. A voyage in 'per_date' mode is driven entirely by
+  //    per-date overrides, so an empty PAX table is expected, not a gap.
+  const [{ data: voyageMarginRows }, { data: settingsRows }] = await Promise.all([
+    supabase.from('voyage_margins').select('voyage_slug').eq('deleted', false),
+    supabase.from('voyage_margin_settings').select('voyage_slug, config_mode'),
+  ])
   const slugsWithConfig = new Set((voyageMarginRows || []).map(r => r.voyage_slug))
+  const modeBySlug = new Map((settingsRows || []).map(r => [r.voyage_slug, r.config_mode]))
 
   // 5) Index bookings by travel_date_id
   const bookingsByDate = new Map()
@@ -106,7 +99,14 @@ export default defineEventHandler(async (event) => {
     }
 
     const isFinished = td.return_date && dayjs(td.return_date).isBefore(today)
-    const hasConfig = td.margin_override_per_traveler != null || slugsWithConfig.has(td.travel_slug)
+
+    // In 'per_date' mode the PAX table is deliberately empty — only the date's own
+    // override counts. In 'pax_table' mode either source works.
+    const mode = modeBySlug.get(td.travel_slug) || 'pax_table'
+    const hasConfig = mode === 'excluded'
+      ? false
+      : td.margin_override_per_traveler !== null
+        || (mode === 'pax_table' && slugsWithConfig.has(td.travel_slug))
 
     if (!voyagesMap.has(td.travel_slug)) {
       voyagesMap.set(td.travel_slug, {
@@ -131,6 +131,7 @@ export default defineEventHandler(async (event) => {
   const voyages = Array.from(voyagesMap.values()).map(v => ({
     voyage_slug: v.voyage_slug,
     has_pax_config: slugsWithConfig.has(v.voyage_slug),
+    config_mode: modeBySlug.get(v.voyage_slug) || 'pax_table',
     totals: {
       estimated: v.estimated,
       finished_count: v.finished_count,

--- a/server/api/v1/booking/margins/dashboard/[slug].get.js
+++ b/server/api/v1/booking/margins/dashboard/[slug].get.js
@@ -24,14 +24,22 @@ export default defineEventHandler(async (event) => {
     .from('travel_dates')
     .select('id, travel_slug, departure_date, return_date, margin_override_per_traveler, real_traveler_count_override, max_travelers, booked_seat')
     .eq('travel_slug', slug)
-    .not('deleted', 'is', true)
-    .not('is_test', 'is', true)
+    .eq('deleted', false)
+    .eq('is_test', false)
     .gte('departure_date', dateFrom)
     .lte('departure_date', dateTo)
     .order('departure_date', { ascending: true })
 
   if (tdError) throw createError({ statusCode: 500, statusMessage: tdError.message })
-  if (!travelDates?.length) return { dates: [], totals: { estimated: 0, real: null, variance: null, finished_count: 0, total_count: 0, real_dates_count: 0 } }
+  if (!travelDates?.length) {
+    return {
+      dates: [],
+      config_mode: 'pax_table',
+      child_margin_delta: null,
+      seasons: [],
+      totals: { estimated: 0, real: null, variance: null, finished_count: 0, total_count: 0, real_dates_count: 0 },
+    }
+  }
 
   // 2) Bookings (paying seats) for those dates — small list, no chunking needed.
   const dateIds = travelDates.map(d => d.id)
@@ -39,6 +47,7 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('travel_date_id, deal_id, booked_places')
     .in('travel_date_id', dateIds)
+    .eq('deleted', false)
     .gt('booked_places', 0)
   if (bookingsError) throw createError({ statusCode: 500, statusMessage: bookingsError.message })
 
@@ -48,7 +57,7 @@ export default defineEventHandler(async (event) => {
   if (dealIds.length) {
     const { data, error } = await supabase
       .from('activecampaign_deals')
-      .select('id, pipeline_id, total_margin, flight_margin, insurance_commission, extra_margin_per_traveler, applied_promo_per_traveler, nb_traveler')
+      .select('id, pipeline_id, total_margin, flight_margin, insurance_commission, extra_margin_per_traveler, applied_promo_per_traveler, nb_traveler, nb_children')
       .in('id', dealIds)
       .eq('pipeline_id', 2)
     if (error) throw createError({ statusCode: 500, statusMessage: error.message })
@@ -56,25 +65,27 @@ export default defineEventHandler(async (event) => {
   }
   const dealsById = new Map(deals.map(d => [Number(d.id), d]))
 
-  // 4) PAX margin table for this voyage — all years; we resolve per-date below.
-  const { data: paxRows } = await supabase
-    .from('voyage_margins')
-    .select('pax, margin_per_traveler, year')
-    .eq('voyage_slug', slug)
+  // 4) Margin config for this voyage — PAX rows (all years, all seasons), the
+  //    recurring seasons, and the settings (child delta). Fetched once, then
+  //    resolved per date in memory via margins.resolveBaseFromRows so the lookup
+  //    order (season → default, each with the nearest-year fallback) lives in
+  //    exactly one place, shared with the single-date path.
+  const [{ data: paxRows }, seasons, settings] = await Promise.all([
+    supabase
+      .from('voyage_margins')
+      .select('pax, margin_per_traveler, year, season_id')
+      .eq('voyage_slug', slug),
+    margins.getSeasonsForVoyage(slug),
+    margins.getSettingsForVoyage(slug),
+  ])
 
-  // Build a Map<pax, Array<{year, margin_per_traveler}>> for in-memory fallback lookup.
-  // We delegate the actual nearest-year selection to margins.pickNearestYearCandidate
-  // so the rule (conservative tie-breaker) stays in one place.
-  const paxYearMap = new Map()
+  const childDelta = Number(settings.child_margin_delta || 0)
+
+  const rowsByPax = new Map()
   for (const r of paxRows || []) {
-    if (r.margin_per_traveler == null) continue
-    if (!paxYearMap.has(r.pax)) paxYearMap.set(r.pax, [])
-    paxYearMap.get(r.pax).push({ year: r.year, margin_per_traveler: Number(r.margin_per_traveler) })
-  }
-
-  function resolvePaxMargin(pax, departureYear) {
-    const best = margins.pickNearestYearCandidate(paxYearMap.get(pax) || [], departureYear)
-    return best ? { value: best.margin_per_traveler, year: best.year } : null
+    if (r.margin_per_traveler === null) continue
+    if (!rowsByPax.has(r.pax)) rowsByPax.set(r.pax, [])
+    rowsByPax.get(r.pax).push(r)
   }
 
   // 5) Group bookings by date
@@ -84,7 +95,7 @@ export default defineEventHandler(async (event) => {
     bookingsByDate.get(b.travel_date_id).push(b)
   }
 
-  // 6) Compute breakdown per date — v2 formula
+  // 6) Compute breakdown per date — v3 formula
   const today = dayjs()
   let totalEst = 0
   let totalReal = 0
@@ -104,24 +115,26 @@ export default defineEventHandler(async (event) => {
       : computedRealPax
 
     const totals = margins.aggregateDealTotals(paidDealsForDate)
+    const childPax = margins.clampChildPax(totals.child_pax, realPax)
 
     let baseMargin = null
     let source = null
     let sourceYear = null
+    let seasonLabel = null
     if (td.margin_override_per_traveler != null) {
       baseMargin = Number(td.margin_override_per_traveler)
       source = 'override'
     }
     else if (realPax > 0) {
-      const departureYear = td.departure_date
-        ? new Date(td.departure_date).getFullYear()
-        : new Date().getFullYear()
-      const resolved = resolvePaxMargin(realPax, departureYear)
-      if (resolved) {
-        baseMargin = resolved.value
-        source = 'pax'
-        sourceYear = resolved.year
-      }
+      const resolved = margins.resolveBaseFromRows({
+        rows: rowsByPax.get(realPax) || [],
+        seasons,
+        departureDate: td.departure_date,
+      })
+      baseMargin = resolved.value
+      source = resolved.source
+      sourceYear = resolved.source_year
+      seasonLabel = resolved.season_label
     }
 
     const real = margins.computeRealMargin({
@@ -129,6 +142,8 @@ export default defineEventHandler(async (event) => {
       realPax,
       additionalMargins: totals.additional_margins,
       promoDeductions: totals.promo_deductions,
+      childDelta,
+      childPax,
     })
     const isFinished = td.return_date && dayjs(td.return_date).isBefore(today)
 
@@ -144,6 +159,7 @@ export default defineEventHandler(async (event) => {
       departure_date: td.departure_date,
       return_date: td.return_date,
       real_pax: realPax,
+      child_pax: childPax,
       booked_seat: td.booked_seat,
       max_travelers: td.max_travelers,
       estimated: totals.estimated,
@@ -153,11 +169,15 @@ export default defineEventHandler(async (event) => {
       has_config: baseMargin != null,
       source,
       source_year: sourceYear,
+      season_label: seasonLabel,
     }
   })
 
   return {
     dates,
+    config_mode: settings.config_mode,
+    child_margin_delta: settings.child_margin_delta ?? null,
+    seasons: seasons.map(s => s.label),
     totals: {
       estimated: totalEst,
       real: totalRealCount > 0 ? totalReal : null,

--- a/server/api/v1/booking/margins/index.get.js
+++ b/server/api/v1/booking/margins/index.get.js
@@ -1,29 +1,138 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, getQuery, createError } from 'h3'
+
+// Configuration status, scoped to one departure year (?year=2027, default: current year).
+//
+// Margins are entered per year, so "configured or not" only means something for a
+// given year: a voyage fully set up for 2026 can be untouched for 2027. `available_years`
+// is derived from the departure dates actually present, which is what makes the
+// Configuration tab roll over on its own (2027 → 2028 → …).
+
+const STATUS = {
+  EXCLUDED: 'excluded',
+  CONFIGURED: 'configured',
+  PARTIAL: 'partial',
+  UNCONFIGURED: 'unconfigured',
+}
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
   if (isProdEnv) requireBookingUser(event)
 
-  const { data, error } = await supabase
-    .from('voyage_margins')
-    .select('voyage_slug, pax')
+  const currentYear = new Date().getFullYear()
+  const requestedYear = Number(getQuery(event).year)
+  const targetYear = Number.isInteger(requestedYear) ? requestedYear : currentYear
 
-  if (error) {
-    throw createError({ statusCode: 500, statusMessage: error.message })
+  // Keep one year of history available in the selector alongside the future ones.
+  const historyFloor = `${currentYear - 1}-01-01`
+
+  const [marginRows, seasonRows, settingsRows, travelDates] = await Promise.all([
+    fetchAllPaginated(() =>
+      supabase.from('voyage_margins').select('voyage_slug, pax, year, season_id, margin_per_traveler'),
+    ),
+    fetchAllPaginated(() =>
+      supabase.from('voyage_margin_seasons').select('id, voyage_slug, label, sort_order'),
+    ),
+    fetchAllPaginated(() =>
+      supabase.from('voyage_margin_settings').select('voyage_slug, config_mode, child_margin_delta'),
+    ),
+    fetchAllPaginated(() =>
+      supabase
+        .from('travel_dates')
+        .select('travel_slug, departure_date, margin_override_per_traveler')
+        .eq('deleted', false)
+        .eq('is_test', false)
+        .gte('departure_date', historyFloor),
+    ),
+  ]).catch((err) => {
+    throw createError({ statusCode: 500, statusMessage: err.message })
+  })
+
+  const settingsBySlug = new Map(settingsRows.map(s => [s.voyage_slug, s]))
+
+  const seasonsBySlug = new Map()
+  for (const s of seasonRows) {
+    if (!seasonsBySlug.has(s.voyage_slug)) seasonsBySlug.set(s.voyage_slug, [])
+    seasonsBySlug.get(s.voyage_slug).push(s)
   }
 
-  // Group by slug → { voyage_slug, configured_pax_count, configured_pax: [int] }
-  const bySlug = new Map()
-  for (const row of data || []) {
-    const entry = bySlug.get(row.voyage_slug) || { voyage_slug: row.voyage_slug, configured_pax: [] }
-    entry.configured_pax.push(row.pax)
-    bySlug.set(row.voyage_slug, entry)
-  }
+  // Every slug we know anything about: margin rows, seasons, settings, or dates.
+  // Slugs missing from the response are simply unconfigured with no departure —
+  // the client fills those in from the Sanity voyage list.
+  const slugs = new Set([
+    ...marginRows.map(r => r.voyage_slug),
+    ...seasonRows.map(r => r.voyage_slug),
+    ...settingsRows.map(r => r.voyage_slug),
+    ...travelDates.map(r => r.travel_slug).filter(Boolean),
+  ])
 
-  return Array.from(bySlug.values()).map(e => ({
-    voyage_slug: e.voyage_slug,
-    configured_pax_count: e.configured_pax.length,
-    configured_pax: e.configured_pax.sort((a, b) => a - b),
-  }))
+  const yearOf = departureDate => margins.getDepartureYear(departureDate)
+
+  const availableYears = [...new Set([
+    currentYear,
+    currentYear + 1,
+    ...travelDates.map(d => yearOf(d.departure_date)),
+  ])].sort((a, b) => a - b)
+
+  const voyages = [...slugs].map((slug) => {
+    const settings = settingsBySlug.get(slug)
+    const configMode = settings?.config_mode || 'pax_table'
+    const seasons = (seasonsBySlug.get(slug) || []).sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+
+    const rowsForYear = marginRows.filter(r =>
+      r.voyage_slug === slug && r.year === targetYear && r.margin_per_traveler !== null,
+    )
+    const configuredPaxCount = new Set(rowsForYear.map(r => r.pax)).size
+
+    // A season with no row for this year still resolves through the season-less
+    // default rows, so this is a warning ("partiel"), not a hard failure.
+    const seasonsMissing = seasons
+      .filter(s => !rowsForYear.some(r => r.season_id === s.id))
+      .map(s => s.label)
+
+    const datesForYear = travelDates.filter(d =>
+      d.travel_slug === slug && yearOf(d.departure_date) === targetYear,
+    )
+    const datesWithOverride = datesForYear.filter(d => d.margin_override_per_traveler !== null).length
+
+    let status
+    let statusDetail = null
+
+    if (configMode === 'excluded') {
+      status = STATUS.EXCLUDED
+    }
+    else if (configMode === 'per_date') {
+      statusDetail = `${datesWithOverride} / ${datesForYear.length} dates`
+      if (datesForYear.length > 0 && datesWithOverride === datesForYear.length) status = STATUS.CONFIGURED
+      else if (datesWithOverride > 0) status = STATUS.PARTIAL
+      else status = STATUS.UNCONFIGURED
+    }
+    else if (configuredPaxCount === 0) {
+      status = STATUS.UNCONFIGURED
+    }
+    else if (seasonsMissing.length) {
+      status = STATUS.PARTIAL
+      statusDetail = `saison ${seasonsMissing.join(', ')} non renseignée`
+    }
+    else {
+      status = STATUS.CONFIGURED
+      statusDetail = `${configuredPaxCount} paliers pax`
+    }
+
+    return {
+      voyage_slug: slug,
+      config_mode: configMode,
+      child_margin_delta: settings?.child_margin_delta ?? null,
+      season_count: seasons.length,
+      season_labels: seasons.map(s => s.label),
+      seasons_missing: seasonsMissing,
+      configured_pax_count: configuredPaxCount,
+      dates_total: datesForYear.length,
+      dates_with_override: datesWithOverride,
+      status,
+      status_detail: statusDetail,
+    }
+  })
+
+  return { year: targetYear, available_years: availableYears, voyages }
 })

--- a/server/utils/margins.js
+++ b/server/utils/margins.js
@@ -1,7 +1,235 @@
 import supabase from './supabase'
 
 // =========================================================================
-// Voyage-level margin table (Pattern A: margin per pax × year)
+// Dates
+// =========================================================================
+
+// travel_dates.departure_date is a Postgres `date` → 'YYYY-MM-DD'. Parse the
+// string directly rather than through `new Date()`: that would give UTC midnight,
+// which lands on the previous day (and possibly the previous month/year) in any
+// negative-offset timezone — enough to put a departure in the wrong season.
+const parseDateParts = (value) => {
+  if (!value) return null
+  const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (match) return { year: Number(match[1]), month: Number(match[2]), day: Number(match[3]) }
+
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() }
+}
+
+const getDepartureYear = departureDate =>
+  parseDateParts(departureDate)?.year ?? new Date().getFullYear()
+
+// =========================================================================
+// Seasons (Pattern C: recurring DD/MM windows, defined once per voyage)
+// =========================================================================
+// Amounts stay per year in voyage_margins — only the window recurs. A date is
+// always attached to the calendar year of its departure, wrapping season or not:
+// a 15/01/2027 departure inside "Haute saison 01/10 → 30/04" reads the 2027 amounts.
+
+// Encodes a month/day pair as a comparable integer: 15/03 → 315.
+const monthDayKey = (month, day) => Number(month) * 100 + Number(day)
+
+// Expands a season into 1-2 non-wrapping intervals on the 101..1231 scale, so
+// containment and overlap are plain interval math. A season crossing 31/12
+// (start > end) becomes [start, 1231] + [101, end].
+const seasonIntervals = (season) => {
+  const start = monthDayKey(season.start_month, season.start_day)
+  const end = monthDayKey(season.end_month, season.end_day)
+  return start <= end ? [[start, end]] : [[start, 1231], [101, end]]
+}
+
+const seasonContainsDate = (season, departureDate) => {
+  const parts = parseDateParts(departureDate)
+  if (!parts) return false
+  const md = monthDayKey(parts.month, parts.day)
+  return seasonIntervals(season).some(([start, end]) => md >= start && md <= end)
+}
+
+// Lowest sort_order wins if two seasons somehow overlap (writes are validated,
+// but rows predating a validation fix shouldn't make the resolver non-deterministic).
+const matchSeasonForDate = (seasons, departureDate) => {
+  if (!departureDate || !seasons?.length) return null
+  return [...seasons]
+    .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+    .find(s => seasonContainsDate(s, departureDate)) || null
+}
+
+// Returns the first overlapping pair as [seasonA, seasonB], or null when clean.
+const findSeasonOverlap = (seasons) => {
+  for (let i = 0; i < seasons.length; i++) {
+    for (let j = i + 1; j < seasons.length; j++) {
+      const overlaps = seasonIntervals(seasons[i]).some(([aStart, aEnd]) =>
+        seasonIntervals(seasons[j]).some(([bStart, bEnd]) => aStart <= bEnd && bStart <= aEnd),
+      )
+      if (overlaps) return [seasons[i], seasons[j]]
+    }
+  }
+  return null
+}
+
+// Feb allows 29 so a leap-year window can be entered; the season only ever
+// matches dates that actually exist.
+const DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+const validateSeasons = (seasons) => {
+  for (const s of seasons) {
+    if (!s.label?.trim()) return 'Chaque saison doit avoir un nom.'
+    for (const [month, day, side] of [
+      [s.start_month, s.start_day, 'de début'],
+      [s.end_month, s.end_day, 'de fin'],
+    ]) {
+      if (!Number.isInteger(month) || month < 1 || month > 12) {
+        return `Mois ${side} invalide pour « ${s.label} ».`
+      }
+      if (!Number.isInteger(day) || day < 1 || day > DAYS_IN_MONTH[month - 1]) {
+        return `Jour ${side} invalide pour « ${s.label} » (le mois ${month} a ${DAYS_IN_MONTH[month - 1]} jours max).`
+      }
+    }
+  }
+
+  const overlap = findSeasonOverlap(seasons)
+  if (overlap) {
+    return `Les saisons « ${overlap[0].label} » et « ${overlap[1].label} » se chevauchent. Les périodes doivent être disjointes.`
+  }
+  return null
+}
+
+const getSeasonsForVoyage = async (voyageSlug) => {
+  const { data, error } = await supabase
+    .from('voyage_margin_seasons')
+    .select('id, label, start_month, start_day, end_month, end_day, sort_order')
+    .eq('voyage_slug', voyageSlug)
+    .order('sort_order', { ascending: true })
+
+  if (error) throw error
+  return data || []
+}
+
+// Replace-all semantics: the editor sends the full season list for the voyage.
+// Seasons dropped from the payload are deleted, which cascades to their
+// voyage_margins rows (ON DELETE CASCADE) — the amounts of a removed season
+// have no meaning left.
+const replaceSeasonsForVoyage = async (voyageSlug, seasons, editorEmail) => {
+  if (!Array.isArray(seasons)) throw new Error('seasons must be an array')
+
+  const normalized = seasons.map((s, index) => ({
+    id: s.id || null,
+    label: String(s.label || '').trim(),
+    start_month: Number(s.start_month),
+    start_day: Number(s.start_day),
+    end_month: Number(s.end_month),
+    end_day: Number(s.end_day),
+    sort_order: Number.isInteger(s.sort_order) ? s.sort_order : index,
+  }))
+
+  const validationError = validateSeasons(normalized)
+  if (validationError) {
+    const err = new Error(validationError)
+    err.statusCode = 400
+    throw err
+  }
+
+  const keptIds = normalized.map(s => s.id).filter(Boolean)
+  let deleteQuery = supabase.from('voyage_margin_seasons').delete().eq('voyage_slug', voyageSlug)
+  if (keptIds.length) deleteQuery = deleteQuery.not('id', 'in', `(${keptIds.join(',')})`)
+  const { error: deleteError } = await deleteQuery
+  if (deleteError) throw deleteError
+
+  if (!normalized.length) return []
+
+  const common = s => ({
+    label: s.label,
+    start_month: s.start_month,
+    start_day: s.start_day,
+    end_month: s.end_month,
+    end_day: s.end_day,
+    sort_order: s.sort_order,
+    voyage_slug: voyageSlug,
+    updated_at: new Date().toISOString(),
+    updated_by: editorEmail || null,
+  })
+
+  const RETURNING = 'id, label, start_month, start_day, end_month, end_day, sort_order'
+
+  // Existing and new seasons cannot share one upsert call: supabase-js pads every
+  // row of a batch to the same key set, so a new season would be sent with
+  // `id: null` and trip the NOT NULL primary key. Updates keep their id (and with
+  // it their voyage_margins amounts); inserts omit the column so the DB default
+  // generates one.
+  const updates = normalized.filter(s => s.id)
+  const inserts = normalized.filter(s => !s.id)
+  const saved = []
+
+  if (updates.length) {
+    const { data, error } = await supabase
+      .from('voyage_margin_seasons')
+      .upsert(updates.map(s => ({ id: s.id, ...common(s) })), { onConflict: 'id' })
+      .select(RETURNING)
+    if (error) throw error
+    saved.push(...(data || []))
+  }
+
+  if (inserts.length) {
+    const { data, error } = await supabase
+      .from('voyage_margin_seasons')
+      .insert(inserts.map(common))
+      .select(RETURNING)
+    if (error) throw error
+    saved.push(...(data || []))
+  }
+
+  return saved.sort((a, b) => a.sort_order - b.sort_order)
+}
+
+// =========================================================================
+// Per-voyage settings (config mode + child margin delta)
+// =========================================================================
+
+const DEFAULT_SETTINGS = { config_mode: 'pax_table', child_margin_delta: null }
+const CONFIG_MODES = ['pax_table', 'per_date', 'excluded']
+
+const getSettingsForVoyage = async (voyageSlug) => {
+  const { data, error } = await supabase
+    .from('voyage_margin_settings')
+    .select('voyage_slug, config_mode, child_margin_delta, updated_at, updated_by')
+    .eq('voyage_slug', voyageSlug)
+    .maybeSingle()
+
+  if (error) throw error
+  return data || { voyage_slug: voyageSlug, ...DEFAULT_SETTINGS }
+}
+
+const upsertSettingsForVoyage = async (voyageSlug, { config_mode, child_margin_delta }, editorEmail) => {
+  const update = { voyage_slug: voyageSlug, updated_at: new Date().toISOString(), updated_by: editorEmail || null }
+
+  if (config_mode !== undefined) {
+    if (!CONFIG_MODES.includes(config_mode)) {
+      const err = new Error(`config_mode doit être ${CONFIG_MODES.join(', ')}`)
+      err.statusCode = 400
+      throw err
+    }
+    update.config_mode = config_mode
+  }
+  if (child_margin_delta !== undefined) {
+    update.child_margin_delta = child_margin_delta === null || child_margin_delta === ''
+      ? null
+      : Number(child_margin_delta)
+  }
+
+  const { data, error } = await supabase
+    .from('voyage_margin_settings')
+    .upsert(update, { onConflict: 'voyage_slug' })
+    .select('voyage_slug, config_mode, child_margin_delta')
+    .single()
+
+  if (error) throw error
+  return data
+}
+
+// =========================================================================
+// Voyage-level margin table (Pattern A: margin per pax × year × season)
 // =========================================================================
 
 // If `year` is omitted, returns all years sorted by year DESC then pax ASC
@@ -9,7 +237,7 @@ import supabase from './supabase'
 const getMarginForVoyage = async (voyageSlug, year = null) => {
   let q = supabase
     .from('voyage_margins')
-    .select('pax, margin_per_traveler, year, updated_at, updated_by')
+    .select('pax, margin_per_traveler, year, season_id, updated_at, updated_by')
     .eq('voyage_slug', voyageSlug)
     .order('year', { ascending: false })
     .order('pax', { ascending: true })
@@ -21,7 +249,9 @@ const getMarginForVoyage = async (voyageSlug, year = null) => {
   return data || []
 }
 
-const upsertMarginForVoyage = async (voyageSlug, rows, editorEmail, year) => {
+// `seasonId` null targets the "toutes saisons" default rows. The unique
+// constraint is NULLS NOT DISTINCT, so a null season upserts like any other value.
+const upsertMarginForVoyage = async (voyageSlug, rows, editorEmail, year, seasonId = null) => {
   if (!Array.isArray(rows)) throw new Error('rows must be an array')
   if (year == null) throw new Error('year is required')
 
@@ -31,6 +261,7 @@ const upsertMarginForVoyage = async (voyageSlug, rows, editorEmail, year) => {
       voyage_slug: voyageSlug,
       pax: r.pax,
       year: Number(year),
+      season_id: seasonId || null,
       margin_per_traveler: r.margin_per_traveler !== null && r.margin_per_traveler !== '' ? Number(r.margin_per_traveler) : null,
       updated_at: new Date().toISOString(),
       updated_by: editorEmail || null,
@@ -40,7 +271,7 @@ const upsertMarginForVoyage = async (voyageSlug, rows, editorEmail, year) => {
 
   const { data, error } = await supabase
     .from('voyage_margins')
-    .upsert(payload, { onConflict: 'voyage_slug,pax,year' })
+    .upsert(payload, { onConflict: 'voyage_slug,pax,year,season_id' })
     .select()
 
   if (error) throw error
@@ -59,6 +290,7 @@ const getPayingBookingsForDate = async (travelDateId) => {
     .from('booked_dates')
     .select('deal_id, booked_places')
     .eq('travel_date_id', travelDateId)
+    .eq('deleted', false)
     .gt('booked_places', 0)
 
   if (bookingsError) throw bookingsError
@@ -69,7 +301,7 @@ const getDealsByIds = async (dealIds) => {
   if (!dealIds.length) return []
   const { data, error } = await supabase
     .from('activecampaign_deals')
-    .select('id, pipeline_id, total_value, total_margin, flight_margin, insurance_commission, extra_margin_per_traveler, applied_promo_per_traveler, nb_traveler')
+    .select('id, pipeline_id, total_value, total_margin, flight_margin, insurance_commission, extra_margin_per_traveler, applied_promo_per_traveler, nb_traveler, nb_children')
     .in('id', dealIds)
     .eq('pipeline_id', 2)
 
@@ -77,7 +309,7 @@ const getDealsByIds = async (dealIds) => {
   return data || []
 }
 
-// Single-pass aggregation over the deals array — returns every total the v2
+// Single-pass aggregation over the deals array — returns every total the v3
 // formula needs. Per-pax fields use THIS deal's nb_traveler (not the global
 // real_pax) so mixed-size deals stay correct.
 //
@@ -87,22 +319,34 @@ const aggregateDealTotals = (deals) => {
     const dealPax = Number(d.nb_traveler || 0)
     acc.estimated += Number(d.total_margin || 0)
     acc.ca += Number(d.total_value || 0)
+    acc.child_pax += Number(d.nb_children || 0)
     acc.additional_margins
       += Number(d.flight_margin || 0)
-      + Number(d.insurance_commission || 0)
-      + Number(d.extra_margin_per_traveler || 0) * dealPax
+        + Number(d.insurance_commission || 0)
+        + Number(d.extra_margin_per_traveler || 0) * dealPax
     acc.promo_deductions += Number(d.applied_promo_per_traveler || 0) * dealPax
     return acc
-  }, { estimated: 0, ca: 0, additional_margins: 0, promo_deductions: 0 })
+  }, { estimated: 0, ca: 0, additional_margins: 0, promo_deductions: 0, child_pax: 0 })
 }
 
-// Pure v2 formula: takes already-aggregated deal totals + base margin info,
+// Pure v3 formula: takes already-aggregated deal totals + base margin info,
 // returns the real margin. Single source of truth used by the per-date util
 // and the batch dashboard endpoint.
-const computeRealMargin = ({ baseMarginPerPax, realPax, additionalMargins, promoDeductions }) => {
+//
+// The child term is algebraically the same as splitting the pax:
+//   base × adults + (base + childDelta) × children  ==  base × pax + childDelta × children
+// A child costs less to buy, so childDelta is normally positive.
+const computeRealMargin = ({ baseMarginPerPax, realPax, additionalMargins, promoDeductions, childDelta = 0, childPax = 0 }) => {
   if (baseMarginPerPax == null) return null
-  return baseMarginPerPax * realPax + additionalMargins - promoDeductions
+  return baseMarginPerPax * realPax
+    + Number(childDelta || 0) * Number(childPax || 0)
+    + additionalMargins
+    - promoDeductions
 }
+
+// real_traveler_count_override is entered by hand and can be lower than the
+// children counted on the deals — never let the child term exceed the pax count.
+const clampChildPax = (childPax, realPax) => Math.max(0, Math.min(Number(childPax || 0), Number(realPax || 0)))
 
 const getTotalInvoicesForDate = async (travelDateId) => {
   const { data, error } = await supabase
@@ -112,44 +356,6 @@ const getTotalInvoicesForDate = async (travelDateId) => {
 
   if (error) throw error
   return (data || []).reduce((acc, r) => acc + Number(r.amount || 0), 0)
-}
-
-/**
- * Resolves the base "margin per traveler" for a date:
- * 1. travel_dates.margin_override_per_traveler (Pattern B) — wins if set
- * 2. voyage_margins[voyage_slug, pax=realPax, year=departureYear]
- * 3. fallback: nearest year with a row at this pax (any direction).
- *    Tie-breaker: prefer the older year (conservative — historical costs are safer).
- * 4. null — no config available
- *
- * Returns { value, source: 'override' | 'pax' | null, source_year?: number }
- */
-const resolveBaseMarginPerPax = async (travelDate, realPax) => {
-  if (travelDate.margin_override_per_traveler !== null && travelDate.margin_override_per_traveler !== undefined) {
-    return { value: Number(travelDate.margin_override_per_traveler), source: 'override' }
-  }
-
-  if (realPax <= 0) return { value: null, source: null }
-
-  const departureYear = travelDate.departure_date
-    ? new Date(travelDate.departure_date).getFullYear()
-    : new Date().getFullYear()
-
-  // Fetch all configured years for this slug+pax (typically 1-3 rows), then pick
-  // the nearest year in JS. Cheaper than two range queries + merge.
-  const { data: candidates } = await supabase
-    .from('voyage_margins')
-    .select('margin_per_traveler, year')
-    .eq('voyage_slug', travelDate.travel_slug)
-    .eq('pax', realPax)
-    .not('margin_per_traveler', 'is', null)
-
-  const best = pickNearestYearCandidate(candidates || [], departureYear)
-  if (best) {
-    return { value: Number(best.margin_per_traveler), source: 'pax', source_year: best.year }
-  }
-
-  return { value: null, source: null }
 }
 
 // Nearest year with conservative tie-breaker (prefer older year on equal distance).
@@ -165,11 +371,82 @@ const pickNearestYearCandidate = (candidates, targetYear) => {
 }
 
 /**
+ * Pure resolver over already-fetched rows — the single place that encodes the
+ * lookup order. Both the per-date util and the batch dashboard endpoint call it,
+ * the only difference being where `rows` and `seasons` come from.
+ *
+ * 1. season matched by departure_date → rows of that season   → 'pax_season'
+ * 2. season-less rows (toutes saisons)                        → 'pax'
+ * 3. null
+ *
+ * Within each level, the year fallback applies (nearest configured year).
+ * The default rows therefore act as a safety net for any season left blank.
+ *
+ * @param {Array} rows    voyage_margins rows for this voyage, already filtered to the target pax
+ * @param {Array} seasons voyage_margin_seasons rows for this voyage
+ */
+const resolveBaseFromRows = ({ rows, seasons, departureDate }) => {
+  const season = matchSeasonForDate(seasons, departureDate)
+  const departureYear = getDepartureYear(departureDate)
+  const usable = (rows || []).filter(r => r.margin_per_traveler !== null && r.margin_per_traveler !== undefined)
+
+  const seasonInfo = { season_id: season?.id ?? null, season_label: season?.label ?? null }
+
+  if (season) {
+    const best = pickNearestYearCandidate(usable.filter(r => r.season_id === season.id), departureYear)
+    if (best) {
+      return { value: Number(best.margin_per_traveler), source: 'pax_season', source_year: best.year, ...seasonInfo }
+    }
+  }
+
+  const fallback = pickNearestYearCandidate(usable.filter(r => !r.season_id), departureYear)
+  if (fallback) {
+    return { value: Number(fallback.margin_per_traveler), source: 'pax', source_year: fallback.year, ...seasonInfo }
+  }
+
+  return { value: null, source: null, source_year: null, ...seasonInfo }
+}
+
+/**
+ * Resolves the base "margin per traveler" for a date:
+ * 1. travel_dates.margin_override_per_traveler (Pattern B) — wins if set
+ * 2. voyage_margins for the matched season / then the season-less default rows,
+ *    each with the nearest-year fallback (see resolveBaseFromRows)
+ * 3. null — no config available
+ */
+const resolveBaseMarginPerPax = async (travelDate, realPax) => {
+  if (travelDate.margin_override_per_traveler !== null && travelDate.margin_override_per_traveler !== undefined) {
+    return { value: Number(travelDate.margin_override_per_traveler), source: 'override', season_id: null, season_label: null }
+  }
+
+  if (realPax <= 0) return { value: null, source: null, season_id: null, season_label: null }
+
+  // Fetch all configured years/seasons for this slug+pax (a handful of rows),
+  // then resolve in JS — cheaper than one query per lookup level.
+  const [seasons, { data: candidates }] = await Promise.all([
+    getSeasonsForVoyage(travelDate.travel_slug),
+    supabase
+      .from('voyage_margins')
+      .select('margin_per_traveler, year, season_id')
+      .eq('voyage_slug', travelDate.travel_slug)
+      .eq('pax', realPax)
+      .not('margin_per_traveler', 'is', null),
+  ])
+
+  return resolveBaseFromRows({
+    rows: candidates || [],
+    seasons,
+    departureDate: travelDate.departure_date,
+  })
+}
+
+/**
  * Full margin computation for a date. Returns the structured breakdown.
  *
  * real_margin = (base_margin_per_pax × real_pax)
- *             + flight_margin                 (sum over deals)
- *             + insurance_commission          (sum over deals)
+ *             + child_margin_delta × nb_children  (sum over deals, clamped to real_pax)
+ *             + flight_margin                     (sum over deals)
+ *             + insurance_commission              (sum over deals)
  *             + extra_margin_per_traveler × nb_traveler   (sum over deals)
  *             − applied_promo_per_traveler × nb_traveler  (sum over deals)
  */
@@ -195,18 +472,24 @@ const computeMarginForDate = async (travelDateId) => {
     : computedRealPax
 
   const totals = aggregateDealTotals(deals)
+  const childPax = clampChildPax(totals.child_pax, realPax)
 
   // Independent of each other and of `totals` — parallelize.
-  const [totalInvoices, baseMargin] = await Promise.all([
+  const [totalInvoices, baseMargin, settings] = await Promise.all([
     getTotalInvoicesForDate(travelDateId),
     resolveBaseMarginPerPax(travelDate, realPax),
+    getSettingsForVoyage(travelDate.travel_slug),
   ])
+
+  const childDelta = Number(settings.child_margin_delta || 0)
 
   const real = computeRealMargin({
     baseMarginPerPax: baseMargin.value,
     realPax,
     additionalMargins: totals.additional_margins,
     promoDeductions: totals.promo_deductions,
+    childDelta,
+    childPax,
   })
 
   const isFinished = travelDate.return_date && new Date(travelDate.return_date) < new Date()
@@ -219,6 +502,12 @@ const computeMarginForDate = async (travelDateId) => {
     base_margin_per_pax: baseMargin.value,
     base_margin_source: baseMargin.source,
     base_margin_source_year: baseMargin.source_year ?? null,
+    season_id: baseMargin.season_id ?? null,
+    season_label: baseMargin.season_label ?? null,
+    child_pax: childPax,
+    child_margin_delta: settings.child_margin_delta !== null ? Number(settings.child_margin_delta) : null,
+    child_margin_total: childDelta * childPax,
+    config_mode: settings.config_mode,
     additional_margins: totals.additional_margins,
     promo_deductions: totals.promo_deductions,
     ca: totals.ca,
@@ -264,9 +553,21 @@ export default {
   upsertMarginForVoyage,
   computeMarginForDate,
   updateMarginOverride,
-  // Pure helpers exposed for the batch dashboard endpoint to keep the v2 formula
-  // and year-fallback rule in one place. Single-date and batch paths both compose these.
+  // Seasons + settings
+  getSeasonsForVoyage,
+  replaceSeasonsForVoyage,
+  getSettingsForVoyage,
+  upsertSettingsForVoyage,
+  CONFIG_MODES,
+  // Pure helpers exposed for the batch dashboard endpoints to keep the v3 formula,
+  // the season matcher and the year-fallback rule in one place. Single-date and
+  // batch paths both compose these.
   aggregateDealTotals,
   computeRealMargin,
+  clampChildPax,
   pickNearestYearCandidate,
+  resolveBaseFromRows,
+  matchSeasonForDate,
+  validateSeasons,
+  getDepartureYear,
 }

--- a/server/utils/supabase.js
+++ b/server/utils/supabase.js
@@ -13,4 +13,22 @@ const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: { persistSession: false },
 })
 
+// PostgREST caps responses at 1000 rows by default — loop with .range() until a
+// short page comes back. Pass a thunk so each page builds a fresh query object.
+//
+//   const rows = await fetchAllPaginated(() => supabase.from('travel_dates').select('id'))
+export const fetchAllPaginated = async (buildQuery, pageSize = 1000) => {
+  const out = []
+  for (let page = 0; ; page++) {
+    const from = page * pageSize
+    const to = from + pageSize - 1
+    const { data, error } = await buildQuery().range(from, to)
+    if (error) throw error
+    if (!data?.length) break
+    out.push(...data)
+    if (data.length < pageSize) break
+  }
+  return out
+}
+
 export default supabase

--- a/supabase/migrations/20260731120000_margins_v3.sql
+++ b/supabase/migrations/20260731120000_margins_v3.sql
@@ -1,0 +1,112 @@
+-- Margins v3: seasonal pricing, child margin delta, per-voyage config mode.
+-- See plan /Users/alex/.claude/plans/tidy-noodling-pizza.md
+--
+-- Three additions, all backwards-compatible — a voyage with no season and no
+-- settings row resolves exactly like it did before this migration:
+--   1. voyage_margin_seasons  — recurring DD/MM windows per voyage (haute/basse saison)
+--   2. voyage_margin_settings — config mode (pax table / per-date / excluded) + child delta
+--   3. voyage_margins.season_id — the seasonal dimension on the existing PAX table
+--
+-- Requires PostgreSQL >= 15 for UNIQUE NULLS NOT DISTINCT. Check with `SELECT version();`
+-- before running (Supabase has shipped 15+ since 2023).
+
+-- =========================================================================
+-- voyage_margin_seasons: recurring month/day windows, defined once per voyage
+-- =========================================================================
+-- No `year` column on purpose: the window recurs every year, only the amounts
+-- in voyage_margins are entered per year. A season may wrap around 31/12
+-- (start 01/10 → end 30/04); the matcher in server/utils/margins.js handles it.
+
+CREATE TABLE IF NOT EXISTS "public"."voyage_margin_seasons" (
+    "id"          uuid                     DEFAULT gen_random_uuid() NOT NULL,
+    "voyage_slug" text                     NOT NULL,
+    "label"       text                     NOT NULL,
+    "start_month" smallint                 NOT NULL,
+    "start_day"   smallint                 NOT NULL,
+    "end_month"   smallint                 NOT NULL,
+    "end_day"     smallint                 NOT NULL,
+    "sort_order"  integer                  DEFAULT 0 NOT NULL,
+    "created_at"  timestamp with time zone DEFAULT now(),
+    "updated_at"  timestamp with time zone DEFAULT now(),
+    "updated_by"  text,
+    CONSTRAINT "voyage_margin_seasons_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "voyage_margin_seasons_start_month_check" CHECK ("start_month" BETWEEN 1 AND 12),
+    CONSTRAINT "voyage_margin_seasons_start_day_check"   CHECK ("start_day"   BETWEEN 1 AND 31),
+    CONSTRAINT "voyage_margin_seasons_end_month_check"   CHECK ("end_month"   BETWEEN 1 AND 12),
+    CONSTRAINT "voyage_margin_seasons_end_day_check"     CHECK ("end_day"     BETWEEN 1 AND 31)
+);
+
+CREATE INDEX IF NOT EXISTS "voyage_margin_seasons_voyage_slug_idx"
+    ON "public"."voyage_margin_seasons" ("voyage_slug");
+
+-- =========================================================================
+-- voyage_margin_settings: one row per voyage
+-- =========================================================================
+-- `config_mode` drives how the Configuration tab decides "configured" vs not:
+--   pax_table — the PAX table (× seasons) is the source of truth  [default]
+--   per_date  — margins are set date by date via margin_override_per_traveler
+--   excluded  — voyage is out of margin tracking, never flagged as unconfigured
+--
+-- `child_margin_delta` is ADDED to the adult margin for each child: the supplier
+-- cost is lower for a child, so the margin is higher. NULL = same as adult.
+
+CREATE TABLE IF NOT EXISTS "public"."voyage_margin_settings" (
+    "voyage_slug"        text                     NOT NULL,
+    "config_mode"        text                     DEFAULT 'pax_table' NOT NULL,
+    "child_margin_delta" numeric,
+    "updated_at"         timestamp with time zone DEFAULT now(),
+    "updated_by"         text,
+    CONSTRAINT "voyage_margin_settings_pkey" PRIMARY KEY ("voyage_slug"),
+    CONSTRAINT "voyage_margin_settings_config_mode_check"
+        CHECK ("config_mode" IN ('pax_table', 'per_date', 'excluded'))
+);
+
+-- =========================================================================
+-- voyage_margins: seasonal dimension
+-- =========================================================================
+-- season_id IS NULL = the "toutes saisons / défaut" row. Every pre-existing row
+-- becomes a default row, so resolution is unchanged until a season is created.
+--
+-- NULLS NOT DISTINCT is required: with the default NULLS DISTINCT, two identical
+-- default rows could coexist and PostgREST's upsert (onConflict) would break.
+
+ALTER TABLE "public"."voyage_margins"
+    ADD COLUMN IF NOT EXISTS "season_id" uuid;
+
+ALTER TABLE "public"."voyage_margins"
+    DROP CONSTRAINT IF EXISTS "voyage_margins_season_id_fkey";
+
+ALTER TABLE "public"."voyage_margins"
+    ADD CONSTRAINT "voyage_margins_season_id_fkey"
+    FOREIGN KEY ("season_id") REFERENCES "public"."voyage_margin_seasons"("id") ON DELETE CASCADE;
+
+ALTER TABLE "public"."voyage_margins"
+    DROP CONSTRAINT IF EXISTS "voyage_margins_voyage_slug_pax_year_key";
+
+ALTER TABLE "public"."voyage_margins"
+    DROP CONSTRAINT IF EXISTS "voyage_margins_slug_pax_year_season_key";
+
+ALTER TABLE "public"."voyage_margins"
+    ADD CONSTRAINT "voyage_margins_slug_pax_year_season_key"
+    UNIQUE NULLS NOT DISTINCT ("voyage_slug", "pax", "year", "season_id");
+
+CREATE INDEX IF NOT EXISTS "voyage_margins_season_id_idx"
+    ON "public"."voyage_margins" ("season_id");
+
+-- =========================================================================
+-- Backfill: auto-detect voyages already driven by per-date overrides
+-- =========================================================================
+-- A voyage with zero PAX rows but at least one date carrying an override was
+-- being counted as "non configuré" — that is exactly the case this migration
+-- fixes (le Japon). Everything else keeps the 'pax_table' default and needs no row.
+
+INSERT INTO "public"."voyage_margin_settings" ("voyage_slug", "config_mode")
+SELECT DISTINCT td."travel_slug", 'per_date'
+FROM "public"."travel_dates" td
+WHERE td."margin_override_per_traveler" IS NOT NULL
+  AND td."travel_slug" IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM "public"."voyage_margins" vm
+      WHERE vm."voyage_slug" = td."travel_slug"
+  )
+ON CONFLICT ("voyage_slug") DO NOTHING;


### PR DESCRIPTION
## Pourquoi

Le tableau de marge du BMS n'avait que deux axes (pax × année). L'équipe booking a remonté quatre cas non couverts :

1. **Prix d'achat haute/basse saison** (Égypte sur les rives du Nil) — impossible de distinguer un départ de janvier d'un départ de juillet.
2. **L'override par date ne pouvait pas servir de contournement** : il fixe un tarif unique par voyageur, qu'il y ait 1 ou 10 pax.
3. **Tarif enfant** — le prix d'achat est plus bas pour les enfants sur plusieurs voyages, ce qui sous-estimait la marge réelle des départs familiaux.
4. **Tri de l'onglet Configuration** — les voyages pilotés par override (le Japon) étaient comptés « non configurés », et le statut était global alors que les tarifs sont annuels : impossible de voir ce qui restait à faire pour 2027.

## Ce que ça change

Trois ajouts, **tous rétrocompatibles** : un voyage sans saison et sans réglages résout exactement comme avant.

| Table | Rôle |
|---|---|
| `voyage_margin_seasons` | Périodes **récurrentes en JJ/MM**, définies une fois par voyage et valables toutes les années. Seuls les montants se saisissent année par année. Une période peut enjamber le 31/12 (01/10 → 30/04). |
| `voyage_margins.season_id` | La dimension saison sur le tableau existant. `NULL` = ligne « toutes saisons », qui sert de filet pour toute saison laissée vide. |
| `voyage_margin_settings` | Mode de configuration (`pax_table` / `per_date` / `excluded`) + écart de marge enfant. |

L'**écart enfant** est un montant unique par voyage, *ajouté* à la marge adulte pour chaque `nb_children` des deals payés (l'achat enfant coûte moins cher), borné au nombre de pax réel. Le palier PAX reste calculé sur le total voyageurs, enfants inclus.

L'**onglet Configuration devient annuel** : les années proposées viennent des départs réellement présents en base, donc le passage 2027 → 2028 se fait tout seul. Un voyage en `per_date` n'est vert que si **tous** ses départs de l'année ont leur override, sinon il affiche « 7 / 12 dates ».

L'ordre de résolution vit dans un seul endroit, `resolveBaseFromRows` : `override` > saison correspondante > lignes par défaut, chaque niveau gardant le repli sur l'année configurée la plus proche. Le chemin fiche date et le chemin dashboard batch composent tous deux ce helper pour ne pas diverger.

## Points d'attention pour la revue

- **La migration est déjà appliquée en production** (projet `ufyskkwszklmrgcifanb`). Elle est idempotente et additive.
- **`UNIQUE NULLS NOT DISTINCT` exige PostgreSQL ≥ 15.** Sans lui, deux lignes « défaut » identiques pourraient coexister et l'upsert PostgREST casserait. Supabase est en 15+ depuis 2023.
- **Backfill automatique** : les voyages sans aucune ligne pax mais avec des overrides existants passent en `per_date`. 5 voyages détectés, dont `voyage-immersion-japon` — le cas du ticket.
- **Suppression d'une saison = suppression de ses montants** (`ON DELETE CASCADE`). C'est voulu et annoncé dans l'UI, mais c'est le point le plus destructif du lot.
- `replaceSeasonsForVoyage` sépare volontairement les `insert` des `upsert` : `supabase-js` uniformise les clés de toutes les lignes d'un lot, donc une nouvelle saison partirait avec `id: null` et violerait la clé primaire. Le bug a été trouvé et corrigé pendant la vérification.

### Corrections attrapées au passage

- Les dates de départ sont parsées depuis la chaîne ISO plutôt que via `new Date()`, qui décalait le mois en fuseau négatif et pouvait ranger un départ dans la mauvaise saison.
- Vider une case du tableau la supprime vraiment, au lieu de conserver silencieusement l'ancien montant.
- `fetchAllPaginated` remonté dans `server/utils/supabase.js`, partagé par les deux endpoints dashboard au lieu d'être dupliqué.

## Vérification

**Sur la base de production, après migration :**

- Saison enjambante : un départ du **07/02/2026** résout en « Haute saison » (01/10 → 30/04) avec la base 420 € et la source `pax_season`.
- Chevauchement refusé en 400 : « Les saisons « Haute saison » et « Chevauche » se chevauchent ».
- Renommer une saison conserve son `id`, donc ses montants.
- Terme enfant : `voyage-nomades-mongolie`, départ du 16/07/2026, 2 pax dont 1 enfant → marge réelle **800 € → 860 €** avec un écart de 60 €, puis retour à 800 € après remise à zéro.
- Dimension année : 2026 → 43 configurés / 5 incomplets / 107 non configurés ; 2027 → 5 / 0 / 150. Le Japon est `8 / 10 dates` en 2026 et `15 / 15` en 2027.
- UI : matrice PAX × Défaut × saisons, héritage affiché colonne par colonne sur l'onglet 2027 (`Hérité 2026 : 420 €`), menu de mode fonctionnel.

**37 contrôles unitaires** sur la logique pure : bornes de saison, enjambement du 31/12, ordre de résolution, repli d'année, équivalence algébrique du terme enfant, clamp, validation 31/02 et mois 13.

Toutes les données de test écrites pendant la vérification ont été supprimées ; les compteurs sont revenus à l'identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
