### PR TITLE
Soft delete standard : plus aucune suppression physique

### DIFF
--- a/app/components/booking/DateAttachments.vue
+++ b/app/components/booking/DateAttachments.vue
@@ -12,6 +12,16 @@
         {{ mdiPaperclip }}
       </v-icon>
       Fichiers joints
+      <v-spacer />
+      <v-switch
+        v-model="showDeleted"
+        label="Supprimés"
+        color="error"
+        density="compact"
+        hide-details
+        class="flex-grow-0 text-caption"
+        @update:model-value="fetchAttachments"
+      />
     </v-card-title>
     <v-card-text>
       <div
@@ -37,7 +47,7 @@
           v-for="(attachment, idx) in attachments"
           :key="attachment.id"
           class="d-flex align-center py-2 px-2 rounded"
-          :class="idx % 2 === 0 ? 'bg-surface-variant' : ''"
+          :class="[idx % 2 === 0 ? 'bg-surface-variant' : '', attachment.deleted ? 'opacity-60' : '']"
         >
           <v-icon
             size="20"
@@ -52,6 +62,12 @@
             </div>
             <div class="text-caption text-medium-emphasis">
               {{ formatFileSize(attachment.file_size) }} — {{ dayjs(attachment.created_at).format('DD/MM/YYYY HH:mm') }}
+              <span
+                v-if="attachment.deleted"
+                class="text-error"
+              >
+                · supprimé par {{ attachment.deleted_by || '?' }}
+              </span>
             </div>
           </div>
           <v-btn
@@ -65,6 +81,17 @@
             <v-icon>{{ mdiDownload }}</v-icon>
           </v-btn>
           <v-btn
+            v-if="attachment.deleted"
+            icon
+            size="x-small"
+            color="primary"
+            variant="text"
+            @click="restoreFile(attachment)"
+          >
+            <v-icon>{{ mdiRestore }}</v-icon>
+          </v-btn>
+          <v-btn
+            v-else
             icon
             size="x-small"
             color="error"
@@ -115,7 +142,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { mdiDelete, mdiDownload, mdiPaperclip } from '@mdi/js'
+import { mdiDelete, mdiDownload, mdiPaperclip, mdiRestore } from '@mdi/js'
 import dayjs from 'dayjs'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 import { formatFileSize, maxFileSizeRule, mimeIcon, mimeIconColor } from '~/utils/fileDisplay'
@@ -131,10 +158,26 @@ const selectedFile = ref(null)
 const uploading = ref(false)
 const uploadError = ref('')
 const downloadingId = ref(null)
+const showDeleted = ref(false)
+
+async function restoreFile(attachment) {
+  if (!confirm('Restaurer ce fichier ?')) return
+  try {
+    await bookingApi.restoreChild(props.slug, props.dateId, 'attachment', attachment.id)
+    await fetchAttachments()
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
+  }
+}
 
 async function fetchAttachments() {
   try {
-    attachments.value = await bookingApi.getAttachments(props.slug, props.dateId)
+    attachments.value = await bookingApi.getAttachments(
+      props.slug,
+      props.dateId,
+      showDeleted.value ? { includeDeleted: true } : {},
+    )
   }
   catch (err) {
     console.error('Error fetching attachments:', err)

--- a/app/components/booking/DateInvoices.vue
+++ b/app/components/booking/DateInvoices.vue
@@ -13,6 +13,15 @@
       </v-icon>
       Factures fournisseurs
       <v-spacer />
+      <v-switch
+        v-model="showDeleted"
+        label="Supprimées"
+        color="error"
+        density="compact"
+        hide-details
+        class="flex-grow-0 mr-3 text-caption"
+        @update:model-value="fetchInvoices"
+      />
       <span class="text-body-2 font-weight-bold">
         {{ formatEur(totalAmount) }}
       </span>
@@ -41,7 +50,7 @@
           v-for="(invoice, idx) in invoices"
           :key="invoice.id"
           class="d-flex align-center py-2 px-2 rounded"
-          :class="idx % 2 === 0 ? 'bg-surface-variant' : ''"
+          :class="[idx % 2 === 0 ? 'bg-surface-variant' : '', invoice.deleted ? 'opacity-60' : '']"
         >
           <v-icon
             size="20"
@@ -59,6 +68,14 @@
               <span v-if="invoice.file_size">{{ formatFileSize(invoice.file_size) }} · </span>
               <span v-else-if="!invoice.file_name">Sans pièce jointe · </span>
               {{ dayjs(invoice.created_at).format('DD/MM/YYYY') }}
+              <span
+                v-if="invoice.deleted"
+                class="text-error"
+              >
+                · supprimée le
+                {{ invoice.deleted_at ? dayjs(invoice.deleted_at).format('DD/MM/YYYY') : '?' }}
+                par {{ invoice.deleted_by || '?' }}
+              </span>
             </div>
           </div>
           <v-text-field
@@ -84,6 +101,17 @@
             <v-icon>{{ mdiDownload }}</v-icon>
           </v-btn>
           <v-btn
+            v-if="invoice.deleted"
+            icon
+            size="x-small"
+            color="primary"
+            variant="text"
+            @click="restoreInvoice(invoice)"
+          >
+            <v-icon>{{ mdiRestore }}</v-icon>
+          </v-btn>
+          <v-btn
+            v-else
             icon
             size="x-small"
             color="error"
@@ -219,7 +247,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { mdiDelete, mdiDownload, mdiPaperclip, mdiReceiptText, mdiReceiptTextOutline } from '@mdi/js'
+import { mdiDelete, mdiDownload, mdiPaperclip, mdiReceiptText, mdiReceiptTextOutline, mdiRestore } from '@mdi/js'
 import dayjs from 'dayjs'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 import { formatEur } from '~/utils/formatNumber'
@@ -235,6 +263,7 @@ const emit = defineEmits(['invoices-changed'])
 const invoices = ref([])
 const loading = ref(true)
 const addTab = ref('with-file')
+const showDeleted = ref(false)
 
 // With file
 const selectedFile = ref(null)
@@ -257,8 +286,10 @@ const canCreateNoFile = computed(() =>
   noFileAmount.value !== null && noFileAmount.value !== '' && noFileLabel.value && noFileLabel.value.trim(),
 )
 
+// Les factures supprimées restent affichées quand le filtre est ouvert, mais ne
+// comptent jamais dans le total : ce montant alimente le calcul de marge.
 const totalAmount = computed(() =>
-  invoices.value.reduce((acc, inv) => acc + Number(inv.amount || 0), 0),
+  invoices.value.reduce((acc, inv) => acc + (inv.deleted ? 0 : Number(inv.amount || 0)), 0),
 )
 
 // Invoices without an attached file fall back to the receipt-outline icon.
@@ -267,13 +298,29 @@ const iconColorFor = invoice => mimeIconColor(invoice.mime_type, 'grey')
 
 async function fetchInvoices() {
   try {
-    invoices.value = await bookingApi.getInvoices(props.slug, props.dateId)
+    invoices.value = await bookingApi.getInvoices(
+      props.slug,
+      props.dateId,
+      showDeleted.value ? { includeDeleted: true } : {},
+    )
   }
   catch (err) {
     console.error('Error fetching invoices:', err)
   }
   finally {
     loading.value = false
+  }
+}
+
+async function restoreInvoice(invoice) {
+  if (!confirm('Restaurer cette facture ?')) return
+  try {
+    await bookingApi.restoreChild(props.slug, props.dateId, 'invoice', invoice.id)
+    await fetchInvoices()
+    emit('invoices-changed')
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
   }
 }
 

--- a/app/components/booking/DateNotes.vue
+++ b/app/components/booking/DateNotes.vue
@@ -12,6 +12,16 @@
         {{ mdiFormatListBulleted }}
       </v-icon>
       Notes & discussion
+      <v-spacer />
+      <v-switch
+        v-model="showDeleted"
+        label="Supprimées"
+        color="error"
+        density="compact"
+        hide-details
+        class="flex-grow-0 text-caption"
+        @update:model-value="fetchNotes"
+      />
     </v-card-title>
     <v-card-text>
       <div
@@ -65,8 +75,26 @@
               <span class="text-caption text-medium-emphasis">
                 {{ dayjs(note.created_at).format('DD/MM/YYYY HH:mm') }}
               </span>
+              <span
+                v-if="note.deleted"
+                class="text-caption text-error"
+              >
+                supprimée par {{ note.deleted_by || '?' }}
+              </span>
               <v-btn
-                v-if="canDelete(note)"
+                v-if="note.deleted"
+                icon
+                size="x-small"
+                color="primary"
+                variant="text"
+                @click="restoreNote(note)"
+              >
+                <v-icon size="14">
+                  {{ mdiRestore }}
+                </v-icon>
+              </v-btn>
+              <v-btn
+                v-else-if="canDelete(note)"
                 icon
                 size="x-small"
                 color="error"
@@ -188,9 +216,9 @@ import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
-import { mdiDelete, mdiFormatListBulleted, mdiLinkVariant } from '@mdi/js'
+import { mdiDelete, mdiFormatListBulleted, mdiLinkVariant, mdiRestore } from '@mdi/js'
 import dayjs from 'dayjs'
-import { bookingApi } from '~/utils/bookingApi'
+import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 
 const props = defineProps({
   slug: { type: String, required: true },
@@ -203,6 +231,7 @@ const loading = ref(true)
 const submitting = ref(false)
 const linkDialog = ref(false)
 const linkUrl = ref('')
+const showDeleted = ref(false)
 
 const editor = useEditor({
   extensions: [
@@ -248,13 +277,28 @@ function applyLink() {
 
 async function fetchNotes() {
   try {
-    notes.value = await bookingApi.getNotes(props.slug, props.dateId)
+    notes.value = await bookingApi.getNotes(
+      props.slug,
+      props.dateId,
+      showDeleted.value ? { includeDeleted: true } : {},
+    )
   }
   catch (err) {
     console.error('Error fetching notes:', err)
   }
   finally {
     loading.value = false
+  }
+}
+
+async function restoreNote(note) {
+  if (!confirm('Restaurer cette note ?')) return
+  try {
+    await bookingApi.restoreChild(props.slug, props.dateId, 'note', note.id)
+    await fetchNotes()
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
   }
 }
 

--- a/app/layouts/booking.vue
+++ b/app/layouts/booking.vue
@@ -193,7 +193,7 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import { useDisplay, useTheme } from 'vuetify'
-import { mdiHome, mdiLogout, mdiViewDashboardOutline, mdiAirplaneTakeoff, mdiCompassOutline, mdiMenu, mdiChevronLeft, mdiChevronRight, mdiCurrencyEur, mdiCardSearchOutline } from '@mdi/js'
+import { mdiHome, mdiLogout, mdiViewDashboardOutline, mdiAirplaneTakeoff, mdiCompassOutline, mdiMenu, mdiChevronLeft, mdiChevronRight, mdiCurrencyEur, mdiCardSearchOutline, mdiDeleteRestore } from '@mdi/js'
 import { useImage } from '#imports'
 
 // Register the `backoffice` theme on demand. Keeping it out of the global
@@ -241,6 +241,7 @@ const navItems = [
   { title: 'Marges', icon: mdiCurrencyEur, to: '/booking-management/margins', exact: false },
   { title: 'Sur-mesure', icon: mdiCompassOutline, to: '/booking-management/custom-travels', exact: false },
   { title: 'Deal AC', icon: mdiCardSearchOutline, to: '/booking-management/deal-inspector', exact: false },
+  { title: 'Corbeille', icon: mdiDeleteRestore, to: '/booking-management/trash', exact: false },
 ]
 
 const bookingUser = useState('bookingUser', () => null)

--- a/app/middleware/oldPayementLinkRedirection.js
+++ b/app/middleware/oldPayementLinkRedirection.js
@@ -3,10 +3,14 @@ export default defineNuxtRouteMiddleware(async () => {
   let query = buildQuery(route)
 
   // Try to find an existing booked date
+  // NB : ce filtre est une correction de justesse, pas un contrôle de sécurité —
+  // la requête part du navigateur avec la clé anon. L'exposition de lecture sur
+  // booked_dates est préexistante et relève d'un ticket RLS à part.
   const { data: existingBookedDate, error: bookedDateError } = await supabase
     .from('booked_dates')
     .select('*')
     .eq('deal_id', route.query.orderId)
+    .eq('deleted', false)
 
   console.log('===========existingBookedDate in oldPayementLinkRedirection.js===========', existingBookedDate)
   if (bookedDateError) {
@@ -33,6 +37,7 @@ export default defineNuxtRouteMiddleware(async () => {
     .select('*')
     .eq('departure_date', deal.departureDate)
     .eq('travel_slug', deal.slug)
+    .eq('deleted', false)
 
   console.log('===========existingTravelDate in oldPayementLinkRedirection.js===========', existingTravelDate)
   if (travelDateError) {

--- a/app/pages/booking-management/[slug]/[dateId].vue
+++ b/app/pages/booking-management/[slug]/[dateId].vue
@@ -17,6 +17,50 @@
     </v-row>
 
     <template v-else>
+      <!-- Date supprimée : bandeau + restauration -->
+      <v-alert
+        v-if="form.deleted"
+        type="error"
+        variant="tonal"
+        class="mb-4"
+        :icon="mdiDelete"
+      >
+        <div class="d-flex align-center justify-space-between flex-wrap ga-3">
+          <div>
+            <strong>Cette date est supprimée.</strong>
+            <div class="text-body-2">
+              Supprimée le
+              {{ form.deleted_at ? dayjs(form.deleted_at).format('DD/MM/YYYY à HH:mm') : '?' }}
+              par {{ form.deleted_by || '?' }}. Elle n'apparaît plus sur le site ni dans les
+              compteurs. Les modifications sont désactivées tant qu'elle n'est pas restaurée.
+            </div>
+          </div>
+          <v-btn
+            color="error"
+            variant="flat"
+            size="small"
+            :prepend-icon="mdiRestore"
+            @click="restoreDate"
+          >
+            Restaurer la date
+          </v-btn>
+        </div>
+      </v-alert>
+
+      <!-- Réservations orphelines (deal AC sans email) -->
+      <v-alert
+        v-if="orphanTravelers.length"
+        type="warning"
+        variant="tonal"
+        class="mb-4"
+      >
+        <strong>{{ orphanTravelers.length }} réservation(s) sans email côté ActiveCampaign.</strong>
+        <div class="text-body-2">
+          Elles ne sont plus supprimées automatiquement. Vérifiez le deal, puis supprimez-les
+          manuellement depuis la liste si elles sont bien obsolètes.
+        </div>
+      </v-alert>
+
       <!-- Header -->
       <v-row class="align-center mb-4">
         <v-col
@@ -664,6 +708,52 @@
                 </v-card-text>
               </v-card>
 
+              <!-- Réservations supprimées (Corbeille) -->
+              <v-card
+                v-if="deletedTravelers.length"
+                class="mt-4 bo-card"
+                rounded="lg"
+                elevation="0"
+              >
+                <v-card-text class="pa-4">
+                  <v-expansion-panels variant="accordion">
+                    <v-expansion-panel>
+                      <v-expansion-panel-title>
+                        <span class="bo-section-title mb-0">
+                          Voyageurs supprimés ({{ deletedTravelers.length }})
+                        </span>
+                      </v-expansion-panel-title>
+                      <v-expansion-panel-text>
+                        <div
+                          v-for="traveler in deletedTravelers"
+                          :key="traveler.id"
+                          class="d-flex align-center justify-space-between py-2"
+                        >
+                          <div>
+                            <div class="text-body-2 font-weight-medium">
+                              {{ traveler.name || traveler.email || `Deal ${traveler.deal_id}` }}
+                            </div>
+                            <div class="text-caption text-medium-emphasis">
+                              {{ deletedTravelerTooltip(traveler) }}
+                              · {{ traveler.booked_places }} place(s)
+                            </div>
+                          </div>
+                          <v-btn
+                            size="x-small"
+                            variant="text"
+                            color="primary"
+                            :prepend-icon="mdiRestore"
+                            @click="restoreTraveler(traveler.id)"
+                          >
+                            Restaurer
+                          </v-btn>
+                        </div>
+                      </v-expansion-panel-text>
+                    </v-expansion-panel>
+                  </v-expansion-panels>
+                </v-card-text>
+              </v-card>
+
               <!-- Notes -->
               <DateNotes
                 :slug="slug"
@@ -980,7 +1070,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { mdiArrowRight, mdiDelete, mdiLinkEdit, mdiInformationOutline, mdiAirplaneTakeoff, mdiCalendarOutline, mdiContentCopy, mdiCalculator, mdiFileDocument, mdiContentDuplicate, mdiLinkVariant, mdiEmailOutline, mdiClockPlusOutline } from '@mdi/js'
+import { mdiArrowRight, mdiDelete, mdiLinkEdit, mdiInformationOutline, mdiAirplaneTakeoff, mdiCalendarOutline, mdiContentCopy, mdiCalculator, mdiFileDocument, mdiContentDuplicate, mdiLinkVariant, mdiEmailOutline, mdiClockPlusOutline, mdiRestore } from '@mdi/js'
 import dayjs from 'dayjs'
 import DateFormCard from '~/components/booking/DateFormCard.vue'
 import DateAttachments from '~/components/booking/DateAttachments.vue'
@@ -1002,6 +1092,10 @@ const config = useRuntimeConfig()
 const form = ref({})
 const bookedTravelers = ref([])
 const prospectTravelers = ref([])
+const deletedTravelers = ref([])
+// Réservations dont le deal AC existe mais n'a pas d'email. booked.get.js les
+// supprimait en dur pendant un simple GET ; elles sont désormais signalées ici.
+const orphanTravelers = ref([])
 const loading = ref(true)
 const sanity = useSanity()
 const snackbar = ref(false)
@@ -1088,17 +1182,62 @@ const previewDate = computed(() => ({
 
 const fetchDetails = async () => {
   try {
+    // includeDeleted : la fiche doit pouvoir s'ouvrir sur une date supprimée
+    // (bandeau + bouton Restaurer) et lister les voyageurs supprimés.
     const [date, travelers] = await Promise.all([
-      bookingApi.getDateById(dateId),
-      bookingApi.getBooked(slug, dateId),
+      bookingApi.getDateById(dateId, { includeDeleted: true }),
+      bookingApi.getBooked(slug, dateId, { includeDeleted: true }),
     ])
     form.value = { ...date, index: 0, badges: date.badges || date.displayed_badges }
-    bookedTravelers.value = (travelers || []).filter(traveler => traveler.booked_places > 0)
-    prospectTravelers.value = (travelers || []).filter(traveler => traveler.booked_places === 0)
+    const active = (travelers || []).filter(t => !t.deleted)
+    bookedTravelers.value = active.filter(traveler => traveler.booked_places > 0)
+    prospectTravelers.value = active.filter(traveler => traveler.booked_places === 0)
+    deletedTravelers.value = (travelers || []).filter(t => t.deleted)
+    orphanTravelers.value = active.filter(t => t.orphan)
   }
   finally {
     loading.value = false
   }
+}
+
+const restoreDate = async () => {
+  if (!confirm('Restaurer cette date et les éléments supprimés avec elle ?')) return
+  try {
+    const res = await bookingApi.restoreDate(slug, dateId)
+    const messages = []
+    for (const c of res?.conflicts || []) {
+      if (c.type === 'booking_reassigned') {
+        messages.push(`Le deal ${c.deal_id} a été ré-assigné à une autre date depuis : il n'a pas été restauré ici.`)
+      }
+      if (c.type === 'duplicate_active_date') {
+        messages.push('Une date active existe déjà pour ce voyage au même départ — vérifiez les doublons.')
+      }
+    }
+    if (res?.departureDealNeedsRecreation) {
+      messages.push('Le dossier de départ avait été supprimé dans ActiveCampaign et n\'est pas récupérable : recréez-le ci-dessous.')
+    }
+    if (messages.length) alert(messages.join('\n\n'))
+    await fetchDetails()
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
+  }
+}
+
+const restoreTraveler = async (id) => {
+  if (!confirm('Restaurer cette réservation ?')) return
+  try {
+    await bookingApi.restoreBooked(slug, dateId, id)
+    await fetchDetails()
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
+  }
+}
+
+const deletedTravelerTooltip = (t) => {
+  const when = t.deleted_at ? dayjs(t.deleted_at).format('DD/MM/YYYY HH:mm') : 'date inconnue'
+  return `Supprimee le ${when} par ${t.deleted_by || 'auteur inconnu'} (${t.deleted_reason || 'raison inconnue'})`
 }
 
 const onSave = async () => {
@@ -1240,8 +1379,15 @@ const onDuplicateDeal = async () => {
 }
 
 const deleteTraveler = async (id) => {
-  if (!confirm('Supprimer ce voyageur ?')) return
-  await bookingApi.deleteBooked(slug, dateId, id)
+  if (!confirm('Supprimer ce voyageur ? La réservation sera masquée et restera restaurable.')) return
+  // Sans ce try/catch, toute erreur serveur remontait en rejet non géré : la
+  // liste n'était pas rafraîchie et l'utilisateur voyait un no-op silencieux.
+  try {
+    await bookingApi.deleteBooked(slug, dateId, id)
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la suppression du voyageur'))
+  }
   await fetchDetails()
 }
 

--- a/app/pages/booking-management/[slug]/index.vue
+++ b/app/pages/booking-management/[slug]/index.vue
@@ -108,6 +108,15 @@
         hide-details
         style="max-width: 180px;"
       />
+      <v-switch
+        v-model="showDeleted"
+        label="Dates supprimées"
+        color="error"
+        density="compact"
+        hide-details
+        class="flex-grow-0"
+        @update:model-value="fetchDates"
+      />
     </div>
 
     <v-card
@@ -128,10 +137,29 @@
         <template #item="{ item }">
           <tr
             class="cursor-pointer"
+            :class="{ 'row-deleted': item.deleted }"
             @click="goToDate(item.id)"
           >
             <td>
+              <v-tooltip
+                v-if="item.deleted"
+                location="top"
+              >
+                <template #activator="{ props: tipProps }">
+                  <v-chip
+                    v-bind="tipProps"
+                    color="error"
+                    label
+                    size="x-small"
+                    variant="tonal"
+                  >
+                    Supprimee
+                  </v-chip>
+                </template>
+                {{ deletedTooltip(item) }}
+              </v-tooltip>
               <v-chip
+                v-else
                 :color="item.is_indiv_travel ? 'info' : item.published ? 'success' : 'warning'"
                 label
                 size="x-small"
@@ -189,6 +217,14 @@
                     Dupliquer
                   </v-list-item>
                   <v-list-item
+                    v-if="item.deleted"
+                    :prepend-icon="mdiRestore"
+                    @click="restoreDate(item)"
+                  >
+                    Restaurer
+                  </v-list-item>
+                  <v-list-item
+                    v-else
                     :prepend-icon="mdiDelete"
                     class="text-error"
                     @click="deleteDate(item)"
@@ -216,7 +252,7 @@ import { useRoute, useRouter } from 'vue-router'
 import dayjs from 'dayjs'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
-import { mdiContentCopy, mdiDotsVertical, mdiDelete, mdiEye, mdiArrowRight, mdiPlus } from '@mdi/js'
+import { mdiContentCopy, mdiDotsVertical, mdiDelete, mdiEye, mdiArrowRight, mdiPlus, mdiRestore } from '@mdi/js'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 
 const loading = ref(false)
@@ -233,6 +269,7 @@ const voyage = ref(null)
 const timeframe = ref('upcoming')
 const publicationFilter = ref('all')
 const sortBy = ref('departure_asc')
+const showDeleted = ref(false)
 
 const headers = [
   { title: 'Publication', key: 'published', sortable: true },
@@ -265,7 +302,7 @@ const fetchDates = async () => {
   loading.value = true
   try {
     voyage.value = voyageSanity.value
-    dates.value = await bookingApi.getDatesBySlug(slug)
+    dates.value = await bookingApi.getDatesBySlug(slug, showDeleted.value ? { includeDeleted: true } : {})
   }
   catch (err) {
     console.error(getApiErrorMessage(err, 'Erreur chargement dates'))
@@ -325,13 +362,53 @@ const duplicateDate = async (date) => {
 }
 
 const deleteDate = async (date) => {
-  if (!confirm('Supprimer cette date ? Attention, toutes les réservations associées à cette date seront également supprimées.')) return
+  if (!confirm('Supprimer cette date ? Les réservations, notes et factures associées seront masquées elles aussi. Tout reste restaurable.')) return
   try {
-    await bookingApi.deleteDate(slug, date.id)
+    const res = await bookingApi.deleteDate(slug, date.id)
+    const c = res?.softDeleted || {}
+    const parts = [
+      c.booked_dates ? `${c.booked_dates} réservation(s)` : null,
+      c.date_notes ? `${c.date_notes} note(s)` : null,
+      c.date_invoices ? `${c.date_invoices} facture(s)` : null,
+      c.date_attachments ? `${c.date_attachments} pièce(s) jointe(s)` : null,
+    ].filter(Boolean)
+    if (parts.length) {
+      alert(`Date masquée — ${parts.join(', ')}. Restaurable via « Dates supprimées ».`)
+    }
     await fetchDates()
   }
   catch (err) {
     alert(getApiErrorMessage(err, 'Erreur lors de la suppression'))
+  }
+}
+
+const deletedTooltip = (item) => {
+  const when = item.deleted_at ? dayjs(item.deleted_at).format('DD/MM/YYYY HH:mm') : 'date inconnue'
+  const who = item.deleted_by || 'auteur inconnu'
+  return `Supprimee le ${when} par ${who} (${item.deleted_reason || 'raison inconnue'})`
+}
+
+const restoreDate = async (date) => {
+  if (!confirm('Restaurer cette date et les éléments supprimés avec elle ?')) return
+  try {
+    const res = await bookingApi.restoreDate(slug, date.id)
+    const messages = []
+    for (const c of res?.conflicts || []) {
+      if (c.type === 'booking_reassigned') {
+        messages.push(`Le deal ${c.deal_id} a été ré-assigné à une autre date depuis : il n'a pas été restauré ici.`)
+      }
+      if (c.type === 'duplicate_active_date') {
+        messages.push('Une date active existe déjà pour ce voyage au même départ — vérifiez les doublons.')
+      }
+    }
+    if (res?.departureDealNeedsRecreation) {
+      messages.push('Le dossier de départ avait été supprimé dans ActiveCampaign et n\'est pas récupérable : recréez-le depuis la fiche de la date.')
+    }
+    if (messages.length) alert(messages.join('\n\n'))
+    await fetchDates()
+  }
+  catch (err) {
+    alert(getApiErrorMessage(err, 'Erreur lors de la restauration'))
   }
 }
 
@@ -378,5 +455,15 @@ onMounted(fetchDates)
 
 .ongoing-pulse {
   animation: pulseGlow 1.8s ease-out infinite;
+}
+
+/* Date soft-deleted : visible mais clairement inactive. */
+.row-deleted {
+  opacity: 0.55;
+}
+
+.row-deleted td {
+  text-decoration: line-through;
+  text-decoration-color: rgba(var(--v-theme-error), 0.5);
 }
 </style>

--- a/app/pages/booking-management/trash.vue
+++ b/app/pages/booking-management/trash.vue
@@ -1,0 +1,501 @@
+<template>
+  <v-container
+    fluid
+    class="py-6"
+  >
+    <v-row class="align-center mb-4">
+      <v-col
+        cols="12"
+        md="8"
+      >
+        <h1 class="text-h5 font-weight-bold mb-1">
+          Corbeille
+        </h1>
+        <p class="text-body-2 text-medium-emphasis mb-0">
+          Rien n'est supprime definitivement. Retrouvez ici les dates, reservations et deals
+          masques, avec la raison et l'auteur de la suppression, et remettez-les en service.
+        </p>
+      </v-col>
+      <v-col
+        cols="12"
+        md="4"
+        class="d-flex justify-end ga-2"
+      >
+        <v-btn
+          variant="tonal"
+          size="small"
+          :loading="loading"
+          @click="fetchTrash"
+        >
+          Rafraichir
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <v-alert
+      v-if="errorMessage"
+      type="error"
+      variant="tonal"
+      class="mb-4"
+      closable
+      @click:close="errorMessage = ''"
+    >
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-alert
+      v-if="noticeMessage"
+      type="info"
+      variant="tonal"
+      class="mb-4"
+      closable
+      @click:close="noticeMessage = ''"
+    >
+      <span style="white-space: pre-line;">{{ noticeMessage }}</span>
+    </v-alert>
+
+    <v-tabs
+      v-model="tab"
+      color="primary"
+      class="mb-4"
+    >
+      <v-tab value="travel_dates">
+        Dates
+        <v-chip
+          size="x-small"
+          class="ml-2"
+          variant="tonal"
+        >
+          {{ counts.travel_dates }}
+        </v-chip>
+      </v-tab>
+      <v-tab value="booked_dates">
+        Reservations
+        <v-chip
+          size="x-small"
+          class="ml-2"
+          variant="tonal"
+        >
+          {{ counts.booked_dates }}
+        </v-chip>
+      </v-tab>
+      <v-tab value="deals">
+        Deals
+        <v-chip
+          size="x-small"
+          class="ml-2"
+          variant="tonal"
+        >
+          {{ counts.deals }}
+        </v-chip>
+      </v-tab>
+    </v-tabs>
+
+    <v-card
+      rounded="lg"
+      class="bo-card"
+      elevation="0"
+    >
+      <div
+        v-if="loading"
+        class="d-flex justify-center py-10"
+      >
+        <v-progress-circular
+          indeterminate
+          color="primary"
+          size="40"
+        />
+      </div>
+
+      <v-window
+        v-else
+        v-model="tab"
+      >
+        <!-- ================= DATES ================= -->
+        <v-window-item value="travel_dates">
+          <div
+            v-if="!trash.travel_dates.length"
+            class="text-center py-10 text-medium-emphasis"
+          >
+            Aucune date supprimee.
+          </div>
+          <v-table
+            v-else
+            density="compact"
+          >
+            <thead>
+              <tr>
+                <th>Voyage</th>
+                <th>Depart</th>
+                <th>Places</th>
+                <th>Supprimee</th>
+                <th>Raison</th>
+                <th class="text-right">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="item in trash.travel_dates"
+                :key="item.id"
+              >
+                <td class="text-body-2">
+                  {{ item.travel_slug }}
+                </td>
+                <td class="text-body-2">
+                  {{ formatDate(item.departure_date) }}
+                </td>
+                <td class="text-body-2">
+                  {{ item.booked_seat }} / {{ item.max_travelers || '-' }}
+                </td>
+                <td class="text-caption">
+                  {{ formatWhen(item) }}
+                </td>
+                <td>
+                  <v-chip
+                    size="x-small"
+                    variant="tonal"
+                    :color="reasonColor(item.deleted_reason)"
+                  >
+                    {{ reasonLabel(item.deleted_reason) }}
+                  </v-chip>
+                </td>
+                <td class="text-right">
+                  <v-btn
+                    size="x-small"
+                    variant="tonal"
+                    color="primary"
+                    :prepend-icon="mdiRestore"
+                    :loading="restoringId === item.id"
+                    @click="onRestoreDate(item)"
+                  >
+                    Restaurer
+                  </v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-window-item>
+
+        <!-- ================= RESERVATIONS ================= -->
+        <v-window-item value="booked_dates">
+          <div
+            v-if="!trash.booked_dates.length"
+            class="text-center py-10 text-medium-emphasis"
+          >
+            Aucune reservation supprimee.
+          </div>
+          <v-table
+            v-else
+            density="compact"
+          >
+            <thead>
+              <tr>
+                <th>Deal</th>
+                <th>Voyage / depart</th>
+                <th>Places</th>
+                <th>Supprimee</th>
+                <th>Raison</th>
+                <th class="text-right">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="item in trash.booked_dates"
+                :key="item.id"
+              >
+                <td class="text-body-2">
+                  <div class="font-weight-medium">
+                    {{ item.deal_title || `Deal ${item.deal_id}` }}
+                  </div>
+                  <div class="text-caption text-medium-emphasis">
+                    #{{ item.deal_id }}
+                    <span v-if="item.deal_status"> — {{ item.deal_status }}</span>
+                  </div>
+                </td>
+                <td class="text-body-2">
+                  {{ item.travel_slug || '—' }}
+                  <div class="text-caption text-medium-emphasis">
+                    {{ formatDate(item.departure_date) }}
+                  </div>
+                </td>
+                <td class="text-body-2">
+                  {{ item.booked_places }}
+                </td>
+                <td class="text-caption">
+                  {{ formatWhen(item) }}
+                </td>
+                <td>
+                  <v-chip
+                    size="x-small"
+                    variant="tonal"
+                    :color="reasonColor(item.deleted_reason)"
+                  >
+                    {{ reasonLabel(item.deleted_reason) }}
+                  </v-chip>
+                </td>
+                <td class="text-right">
+                  <!-- La date parente doit revenir en premier : restaurer une
+                       reservation sous une date supprimee la laisserait invisible. -->
+                  <v-tooltip
+                    v-if="item.parent_deleted"
+                    location="top"
+                  >
+                    <template #activator="{ props: tipProps }">
+                      <span v-bind="tipProps">
+                        <v-btn
+                          size="x-small"
+                          variant="tonal"
+                          disabled
+                        >
+                          Date supprimee
+                        </v-btn>
+                      </span>
+                    </template>
+                    Restaurez d'abord la date de depart, dans l'onglet Dates.
+                  </v-tooltip>
+                  <v-btn
+                    v-else
+                    size="x-small"
+                    variant="tonal"
+                    color="primary"
+                    :prepend-icon="mdiRestore"
+                    :loading="restoringId === item.id"
+                    @click="onRestoreBooked(item)"
+                  >
+                    Restaurer
+                  </v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-window-item>
+
+        <!-- ================= DEALS ================= -->
+        <v-window-item value="deals">
+          <div
+            v-if="!trash.deals.length"
+            class="text-center py-10 text-medium-emphasis"
+          >
+            Aucun deal supprime.
+          </div>
+          <v-table
+            v-else
+            density="compact"
+          >
+            <thead>
+              <tr>
+                <th>Deal</th>
+                <th>Pipeline</th>
+                <th>Vendeur</th>
+                <th>Valeur</th>
+                <th>Supprime</th>
+                <th>Raison</th>
+                <th class="text-right">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="item in trash.deals"
+                :key="item.id"
+              >
+                <td class="text-body-2">
+                  <div class="font-weight-medium">
+                    {{ item.title || `Deal ${item.id}` }}
+                  </div>
+                  <div class="text-caption text-medium-emphasis">
+                    #{{ item.id }}
+                    <span v-if="item.slug"> — {{ item.slug }}</span>
+                  </div>
+                </td>
+                <td class="text-body-2">
+                  {{ item.pipeline_title || '—' }}
+                </td>
+                <td class="text-body-2">
+                  {{ item.seller || '—' }}
+                </td>
+                <td class="text-body-2">
+                  {{ item.total_value != null ? formatEur(item.total_value) : '—' }}
+                </td>
+                <td class="text-caption">
+                  {{ formatWhen(item) }}
+                </td>
+                <td>
+                  <v-chip
+                    size="x-small"
+                    variant="tonal"
+                    :color="reasonColor(item.deleted_reason)"
+                  >
+                    {{ reasonLabel(item.deleted_reason) }}
+                  </v-chip>
+                </td>
+                <td class="text-right">
+                  <v-btn
+                    size="x-small"
+                    variant="tonal"
+                    color="primary"
+                    :prepend-icon="mdiRestore"
+                    :loading="restoringId === item.id"
+                    @click="onRestoreDeal(item)"
+                  >
+                    Restaurer
+                  </v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-window-item>
+      </v-window>
+    </v-card>
+
+    <p class="text-caption text-medium-emphasis mt-3">
+      Les notes, pieces jointes et factures supprimees se restaurent depuis la fiche de leur
+      date, via le filtre « Supprimees » de chaque bloc.
+    </p>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import dayjs from 'dayjs'
+import { mdiRestore } from '@mdi/js'
+import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
+import { formatEur } from '~/utils/formatNumber'
+
+definePageMeta({
+  layout: 'booking',
+  middleware: 'booking-management',
+})
+
+const tab = ref('travel_dates')
+const loading = ref(true)
+const restoringId = ref(null)
+const errorMessage = ref('')
+const noticeMessage = ref('')
+const trash = ref({ travel_dates: [], booked_dates: [], deals: [] })
+
+const counts = computed(() => ({
+  travel_dates: trash.value.travel_dates.length,
+  booked_dates: trash.value.booked_dates.length,
+  deals: trash.value.deals.length,
+}))
+
+// Les libelles suivent l'enum deleted_reason de la migration soft delete.
+const REASONS = {
+  manual: { label: 'Manuelle', color: 'grey' },
+  cascade_travel_date: { label: 'Cascade de la date', color: 'blue-grey' },
+  ac_deal_deleted: { label: 'Deal supprime (AC)', color: 'error' },
+  ac_deal_trashed: { label: 'Deal en corbeille (AC)', color: 'error' },
+  ac_deal_lost: { label: 'Deal perdu (AC)', color: 'warning' },
+  ac_contact_deleted: { label: 'Contact supprime (AC)', color: 'error' },
+  purge: { label: 'Purge', color: 'error' },
+}
+
+const reasonLabel = r => REASONS[r]?.label || r || 'Inconnue'
+const reasonColor = r => REASONS[r]?.color || 'grey'
+
+const formatDate = d => (d ? dayjs(d).format('DD/MM/YYYY') : '—')
+const formatWhen = (item) => {
+  const when = item.deleted_at ? dayjs(item.deleted_at).format('DD/MM/YYYY HH:mm') : '?'
+  return `${when} — ${item.deleted_by || '?'}`
+}
+
+const fetchTrash = async () => {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await bookingApi.getTrash()
+    trash.value = {
+      travel_dates: data.travel_dates || [],
+      booked_dates: data.booked_dates || [],
+      deals: data.deals || [],
+    }
+    if (data.truncated && Object.values(data.truncated).some(Boolean)) {
+      noticeMessage.value = 'Liste tronquee a 200 elements par categorie — restaurez les plus recents d\'abord.'
+    }
+  }
+  catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Erreur lors du chargement de la corbeille')
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+const onRestoreDate = async (item) => {
+  if (!confirm(`Restaurer la date du ${formatDate(item.departure_date)} (${item.travel_slug}) et les elements supprimes avec elle ?`)) return
+  restoringId.value = item.id
+  errorMessage.value = ''
+  try {
+    const res = await bookingApi.restoreDate(item.travel_slug, item.id)
+    const lines = []
+    const r = res?.restored || {}
+    lines.push(`Date restauree — ${r.booked_dates || 0} reservation(s), ${r.date_notes || 0} note(s), ${r.date_invoices || 0} facture(s), ${r.date_attachments || 0} piece(s) jointe(s).`)
+    for (const c of res?.conflicts || []) {
+      if (c.type === 'booking_reassigned') {
+        lines.push(`Le deal ${c.deal_id} a ete re-assigne a une autre date depuis : il n'a pas ete restaure ici.`)
+      }
+      if (c.type === 'duplicate_active_date') {
+        lines.push('Une date active existe deja pour ce voyage au meme depart — verifiez les doublons.')
+      }
+    }
+    if (res?.departureDealNeedsRecreation) {
+      lines.push('Le dossier de depart avait ete supprime dans ActiveCampaign et n\'est pas recuperable : recreez-le depuis la fiche de la date.')
+    }
+    noticeMessage.value = lines.join('\n')
+    await fetchTrash()
+  }
+  catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Erreur lors de la restauration de la date')
+  }
+  finally {
+    restoringId.value = null
+  }
+}
+
+const onRestoreBooked = async (item) => {
+  if (!confirm(`Restaurer la reservation du deal ${item.deal_id} ?`)) return
+  restoringId.value = item.id
+  errorMessage.value = ''
+  try {
+    const res = await bookingApi.restoreBooked(item.travel_slug, item.travel_date_id, item.id)
+    const rec = res?.recomputed
+    noticeMessage.value = rec
+      ? `Reservation restauree — la date affiche desormais ${rec.booked_seat} place(s) reservee(s).`
+      : 'Reservation restauree.'
+    await fetchTrash()
+  }
+  catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Erreur lors de la restauration de la reservation')
+  }
+  finally {
+    restoringId.value = null
+  }
+}
+
+const onRestoreDeal = async (item) => {
+  if (!confirm(`Restaurer le deal ${item.title || item.id} dans les rapports ?`)) return
+  restoringId.value = item.id
+  errorMessage.value = ''
+  try {
+    const res = await bookingApi.restoreDeal(item.id)
+    noticeMessage.value = res?.bookedStillDeleted
+      ? 'Deal restaure dans les rapports. Sa reservation reste supprimee — restaurez-la depuis l\'onglet Reservations si le voyageur doit reprendre sa place.'
+      : 'Deal restaure dans les rapports.'
+    await fetchTrash()
+  }
+  catch (err) {
+    errorMessage.value = getApiErrorMessage(err, 'Erreur lors de la restauration du deal')
+  }
+  finally {
+    restoringId.value = null
+  }
+}
+
+onMounted(fetchTrash)
+</script>

--- a/app/utils/bookingApi.js
+++ b/app/utils/bookingApi.js
@@ -31,16 +31,19 @@ export const bookingApi = {
 
   // Backoffice (booking-management)
   getAllDates: () => apiRequest('/booking/all-dates'),
-  getDatesBySlug: slug => apiRequest(`/booking/${encodeURIComponent(slug)}/dates`),
-  getDateById: dateId => apiRequest(`/booking/date/${encodeURIComponent(dateId)}`),
+  // params accepte { includeDeleted: true } pour alimenter la Corbeille.
+  getDatesBySlug: (slug, params = {}) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/dates${encodeQuery(params)}`),
+  getDateById: (dateId, params = {}) =>
+    apiRequest(`/booking/date/${encodeURIComponent(dateId)}${encodeQuery(params)}`),
   updateDate: (slug, dateId, payload) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}`, 'put', payload),
   deleteDate: (slug, dateId) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}`, 'delete'),
   duplicateDate: (slug, dateId) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/duplicate`, 'post'),
-  getBooked: (slug, dateId) =>
-    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/booked`),
+  getBooked: (slug, dateId, params = {}) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/booked${encodeQuery(params)}`),
   deleteBooked: (slug, dateId, bookedId) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/booked/${encodeURIComponent(bookedId)}`, 'delete'),
   assignDeal: (slug, dateId, payload) =>
@@ -51,6 +54,20 @@ export const bookingApi = {
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/assign-departure-deal`, 'delete'),
   addDate: payload => apiRequest('/booking/add-date', 'post', payload),
 
+  // Restauration (soft delete) — voir supabase/migrations/20260801090000_soft_delete.sql
+  restoreDate: (slug, dateId) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/restore`, 'post'),
+  restoreBooked: (slug, dateId, bookedId) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/booked/${encodeURIComponent(bookedId)}/restore`, 'post'),
+  // resource: 'note' | 'attachment' | 'invoice'
+  restoreChild: (slug, dateId, resource, id) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/restore-child`, 'post', { resource, id }),
+
+  // Corbeille globale — type: 'all' | 'travel_dates' | 'booked_dates' | 'deals'
+  getTrash: (params = {}) => apiRequest(`/booking/trash${encodeQuery(params)}`),
+  restoreDeal: dealId =>
+    apiRequest(`/booking/trash/deal/${encodeURIComponent(dealId)}/restore`, 'post'),
+
   // Duplicate an AC deal onto a test email (booking-management testing tool)
   duplicateDeal: (dealId, payload) =>
     apiRequest(`/ac/deals/${encodeURIComponent(dealId)}/duplicate`, 'post', payload),
@@ -59,8 +76,8 @@ export const bookingApi = {
   inspectDeal: dealId => apiRequest(`/ac/deals/${encodeURIComponent(dealId)}/inspect`),
 
   // Notes
-  getNotes: (slug, dateId) =>
-    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/notes`),
+  getNotes: (slug, dateId, params = {}) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/notes${encodeQuery(params)}`),
   addNote: (slug, dateId, payload) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/notes`, 'post', payload),
   deleteNote: (slug, dateId, noteId) =>
@@ -71,8 +88,8 @@ export const bookingApi = {
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/activity${encodeQuery(params)}`),
 
   // Attachments
-  getAttachments: (slug, dateId) =>
-    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/attachments`),
+  getAttachments: (slug, dateId, params = {}) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/attachments${encodeQuery(params)}`),
   getUploadUrl: (slug, dateId, payload) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/attachments/upload-url`, 'post', payload),
   deleteAttachment: (slug, dateId, attachmentId) =>
@@ -127,8 +144,8 @@ export const bookingApi = {
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/margin-override`, 'put', payload),
 
   // Invoices (supplier purchase invoices per date)
-  getInvoices: (slug, dateId) =>
-    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/invoices`),
+  getInvoices: (slug, dateId, params = {}) =>
+    apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/invoices${encodeQuery(params)}`),
   getInvoiceUploadUrl: (slug, dateId, payload) =>
     apiRequest(`/booking/${encodeURIComponent(slug)}/date/${encodeURIComponent(dateId)}/invoices/upload-url`, 'post', payload),
   createInvoiceWithoutFile: (slug, dateId, payload) =>

--- a/server/api/v1/ac/deals/deal-from-bms.get.js
+++ b/server/api/v1/ac/deals/deal-from-bms.get.js
@@ -7,6 +7,7 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('deal_id')
     .eq('id', bookedId)
+    .eq('deleted', false)
     .single()
   if (error) {
     throw funnelReporter.funnelCreateError({

--- a/server/api/v1/ac/deals/enrich.post.js
+++ b/server/api/v1/ac/deals/enrich.post.js
@@ -62,12 +62,7 @@ export default defineEventHandler(async (event) => {
 
   // 4. Aggregate seat count and update travel_dates status
   try {
-    const { data: allBooked } = await supabase
-      .from('booked_dates')
-      .select('booked_places')
-      .eq('travel_date_id', dateId)
-    const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
-    await booking.updateTravelDate(dateId, totalBooked)
+    await booking.recomputeBookedSeatAndStatus(dateId)
     lap('updateTravelDate')
   }
   catch (err) {

--- a/server/api/v1/ac/deals/update-with-bms.post.ts
+++ b/server/api/v1/ac/deals/update-with-bms.post.ts
@@ -7,6 +7,7 @@ export default defineEventHandler(async (event: H3Event): Promise<TypeDeal> => {
     .from('booked_dates')
     .select('deal_id')
     .eq('id', bookedId)
+    .eq('deleted', false)
     .single()
 
   if (error) {

--- a/server/api/v1/ac/webhooks/contactDelete.post.js
+++ b/server/api/v1/ac/webhooks/contactDelete.post.js
@@ -14,14 +14,16 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Missing contact id' })
     }
 
-    const { error } = await supabase
-      .from('activecampaign_clients')
-      .delete()
-      .eq('contact', contactId)
+    // Soft delete : les vues du dashboard joignent activecampaign_clients pour
+    // afficher le nom du client sur des réservations historiques. Effacer la
+    // ligne blanchissait rétroactivement ces lignes.
+    const removed = await softDelete.remove('activecampaign_clients', q => q.eq('contact', contactId), {
+      user: { email: 'activecampaign' },
+      reason: softDelete.REASONS.AC_CONTACT_DELETED,
+    })
 
-    if (error) {
-      console.error('Supabase delete error:', error)
-      throw createError({ statusCode: 500, message: 'Failed to delete contact' })
+    if (removed.error) {
+      throw createError({ statusCode: 500, message: 'Failed to soft delete contact' })
     }
 
     return { success: true, deletedContactId: contactId }

--- a/server/api/v1/ac/webhooks/dealDelete.post.js
+++ b/server/api/v1/ac/webhooks/dealDelete.post.js
@@ -14,31 +14,40 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'Missing deal id' })
     }
 
-    // Purge booked_dates + sync travel_dates seat count
+    const acUser = { email: 'activecampaign' }
+
+    // Soft delete de la réservation + resync du compteur de places.
+    // retrieveBookedDateByDealId respecte désormais le contrat `null | row` :
+    // le garde ci-dessous garde réellement (il passait systématiquement, car
+    // `.single()` renvoyait un objet d'erreur truthy sur zéro ligne).
     const bookedRow = await booking.retrieveBookedDateByDealId(dealId)
     if (bookedRow) {
       const travel_date_id = bookedRow.travel_date_id
       try {
-        await booking.deleteBookedDateByDealId(dealId)
-        const allBooked = await booking.retrieveBookedPlacesByTravelDateId(travel_date_id)
-        const totalBooked = allBooked.reduce((acc, row) => acc + (row.booked_places || 0), 0)
-        await booking.updateTravelDate(travel_date_id, totalBooked)
+        await booking.softDeleteBookedDateByDealId(dealId, {
+          user: acUser,
+          reason: softDelete.REASONS.AC_DEAL_DELETED,
+        })
+        await booking.recomputeBookedSeatAndStatus(travel_date_id)
         await departures.cleanupDepartureDealIfEmpty(travel_date_id)
+        await logDateActivity(travel_date_id, acUser, 'deal_removed', {
+          deal_id: dealId, booked_id: bookedRow.id, source: 'ac_deal_deleted',
+        })
       }
       catch (err) {
-        console.error('Error purging booking rows for deleted deal:', err)
+        console.error('Error soft-deleting booking rows for deleted deal:', err)
       }
     }
 
-    // Remove archived deal row
-    const { error } = await supabase
-      .from('activecampaign_deals')
-      .delete()
-      .eq('id', dealId)
+    // Soft delete de la ligne miroir : le hard delete trouait l'historique des
+    // dashboards de reporting.
+    const removed = await softDelete.remove('activecampaign_deals', q => q.eq('id', dealId), {
+      user: acUser,
+      reason: softDelete.REASONS.AC_DEAL_DELETED,
+    })
 
-    if (error) {
-      console.error('Supabase delete error:', error)
-      throw createError({ statusCode: 500, message: 'Failed to delete deal' })
+    if (removed.error) {
+      throw createError({ statusCode: 500, message: 'Failed to soft delete deal' })
     }
 
     return { success: true, deletedDealId: dealId }

--- a/server/api/v1/ac/webhooks/dealUpdate.post.js
+++ b/server/api/v1/ac/webhooks/dealUpdate.post.js
@@ -21,6 +21,10 @@ const toBool = (val) => {
   return val === 'Oui' || val === true || val === 'true' || val === '1'
 }
 
+// Auteur des suppressions/restaurations déclenchées par ce webhook, dans la
+// piste d'audit (deleted_by, date_activity_log).
+const AC_USER = { email: 'activecampaign' }
+
 export default defineEventHandler(async (event) => {
   const { token } = getQuery(event)
   if (!token || token !== process.env.ACTIVECAMPAIGN_WEBHOOK_TOKEN) {
@@ -127,26 +131,35 @@ export default defineEventHandler(async (event) => {
         // Continue with Supabase cleanup even if ActiveCampaign deletion fails
         }
 
-        console.log('Attempting to delete deal from Supabase with dealId:', dealId)
+        console.log('Attempting to soft delete deal from Supabase with dealId:', dealId)
         try {
-          await booking.deleteBookedDateByDealId(dealId)
-          console.log('Deal deleted from Supabase successfully')
+          await booking.softDeleteBookedDateByDealId(dealId, {
+            user: AC_USER,
+            reason: softDelete.REASONS.AC_DEAL_TRASHED,
+          })
+          console.log('Deal soft deleted from Supabase successfully')
 
-          // Update travel_dates.booked_seat
-          console.log('Attempting to update travel_dates.booked_seat with travel_date_id:', travel_date_id)
-          const allBooked = await booking.retrieveBookedPlacesByTravelDateId(travel_date_id)
-          const totalBooked = allBooked.reduce((acc, row) => acc + (row.booked_places || 0), 0)
-          await booking.updateTravelDate(travel_date_id, totalBooked)
+          await booking.recomputeBookedSeatAndStatus(travel_date_id)
           console.log('Booked places updated successfully, travel_date_id:', travel_date_id)
 
           // Remove departure record deal if no paying clients remain
           await departures.cleanupDepartureDealIfEmpty(travel_date_id)
+
+          await logDateActivity(travel_date_id, AC_USER, 'deal_removed', {
+            deal_id: dealId, booked_id: bookedRow.id, source: 'ac_deal_trashed',
+          })
         }
         catch (bookingError) {
           console.error('Error in booking operations:', bookingError)
           // Continue with the process even if booking operations fail
         }
       }
+      // La ligne miroir suivait le deal vers la corbeille sans être marquée —
+      // incohérence avec dealDelete, qui lui la supprimait.
+      await softDelete.remove('activecampaign_deals', q => q.eq('id', dealId), {
+        user: AC_USER,
+        reason: softDelete.REASONS.AC_DEAL_TRASHED,
+      })
       return { success: true }
     }
     else if (['Perdu', 'Supprimé'].includes(mapDealStatus(fetchedDeal.status))) {
@@ -160,26 +173,65 @@ export default defineEventHandler(async (event) => {
       else {
         const travel_date_id = bookedRow.travel_date_id
 
-        console.log('Attempting to delete deal from Supabase with dealId:', dealId)
+        console.log('Attempting to soft delete deal from Supabase with dealId:', dealId)
         try {
-          await booking.deleteBookedDateByDealId(dealId)
-          console.log('Deal deleted from Supabase successfully')
+          await booking.softDeleteBookedDateByDealId(dealId, {
+            user: AC_USER,
+            reason: softDelete.REASONS.AC_DEAL_LOST,
+          })
+          console.log('Deal soft deleted from Supabase successfully')
 
-          // Update travel_dates.booked_seat
-          console.log('Attempting to update travel_dates.booked_seat with travel_date_id:', travel_date_id)
-          const allBooked = await booking.retrieveBookedPlacesByTravelDateId(travel_date_id)
-          const totalBooked = allBooked.reduce((acc, row) => acc + (row.booked_places || 0), 0)
-          await booking.updateTravelDate(travel_date_id, totalBooked)
+          await booking.recomputeBookedSeatAndStatus(travel_date_id)
           console.log('Booked places updated successfully, travel_date_id:', travel_date_id)
 
           // Remove departure record deal if no paying clients remain
           await departures.cleanupDepartureDealIfEmpty(travel_date_id)
+
+          await logDateActivity(travel_date_id, AC_USER, 'deal_removed', {
+            deal_id: dealId, booked_id: bookedRow.id, source: 'ac_deal_lost',
+          })
         }
         catch (bookingError) {
           console.error('Error in booking operations:', bookingError)
           // Continue with the process even if booking operations fail
         }
       }
+    }
+    else {
+      // Branche inverse : le deal revient à un état vivant (Ouvert / Gagné, hors
+      // corbeille). Si sa réservation porte une pierre tombale posée par l'un
+      // des deux cas ci-dessus, on la ressuscite.
+      //
+      // Sans ça, marquer un deal « Perdu » par erreur serait une porte à sens
+      // unique — précisément le mode de défaillance que le soft delete existe
+      // pour éliminer.
+      const tombstone = await booking.retrieveBookedDateByDealId(dealId, { includeDeleted: true })
+      const revivable = [softDelete.REASONS.AC_DEAL_LOST, softDelete.REASONS.AC_DEAL_TRASHED]
+      if (tombstone?.deleted && revivable.includes(tombstone.deleted_reason)) {
+        try {
+          const res = await booking.upsertBookedDateForDeal(dealId, null, {}, {
+            user: AC_USER,
+            allowMove: false,
+            resetOnRevive: false,
+          })
+          if (res.row) {
+            await booking.recomputeBookedSeatAndStatus(res.row.travel_date_id)
+            await logDateActivity(res.row.travel_date_id, AC_USER, 'deal_restored', {
+              deal_id: dealId,
+              booked_id: res.row.id,
+              cause: 'ac_status_reopened',
+              previous_reason: tombstone.deleted_reason,
+              status: fetchedDeal.status,
+            })
+            console.log(`[dealUpdate] réservation ressuscitée dealId=${dealId} bookedId=${res.row.id}`)
+          }
+        }
+        catch (reviveError) {
+          console.error('Error reviving booking after deal reopened:', reviveError)
+        }
+      }
+      // La ligne miroir suit le même chemin de retour.
+      await softDelete.restore('activecampaign_deals', q => q.eq('id', dealId))
     }
 
     // Build a clean "seller" display label from the body's owner names

--- a/server/api/v1/alma/index.post.js
+++ b/server/api/v1/alma/index.post.js
@@ -6,15 +6,21 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('deal_id')
     .eq('id', bookedId)
+    .eq('deleted', false)
     .single()
 
   if (error) {
+    // Même politique que stripe/index.post.js : on refuse une NOUVELLE session sur
+    // une réservation supprimée, alors que le webhook entrant la ressuscite.
+    const deleted = await booking.isBookedDateDeleted(bookedId)
     throw funnelReporter.funnelCreateError({
-      statusCode: 400,
-      code: 'ALMA_BOOKED_DATE_NOT_FOUND',
+      statusCode: deleted ? 410 : 400,
+      code: deleted ? 'ALMA_BOOKED_DATE_DELETED' : 'ALMA_BOOKED_DATE_NOT_FOUND',
       step: 'payment',
       origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
-      message: 'Impossible de récupérer le deal depuis booked_dates',
+      message: deleted
+        ? 'Cette réservation a été supprimée, le lien de paiement n\'est plus valide'
+        : 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   const deal_id = data.deal_id

--- a/server/api/v1/booking/[slug]/date/[dateId].put.js
+++ b/server/api/v1/booking/[slug]/date/[dateId].put.js
@@ -49,6 +49,7 @@ export default defineEventHandler(async (event) => {
     .select(allowed.join(','))
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .single()
 
   // Convert badges from string to array if needed
@@ -57,6 +58,7 @@ export default defineEventHandler(async (event) => {
     .update(updateFields)
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .select('*')
     .single()
 

--- a/server/api/v1/booking/[slug]/date/[dateId]/activity.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/activity.get.js
@@ -12,15 +12,7 @@ export default defineEventHandler(async (event) => {
 
   const { limit = 20, offset = 0 } = getQuery(event)
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
 
   const { data, error } = await supabase
     .from('date_activity_log')

--- a/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
@@ -27,6 +27,7 @@ export default defineEventHandler(async (event) => {
     .select('id, travel_slug')
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .single()
   if (travelDateError || !travelDate) {
     throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'ASSIGN_DATE_NOT_FOUND', step: 'details', origin: { field: 'dateId', received: dateId, endpoint: `/booking/${slug}/date/${dateId}/assign-deal` }, message: 'Date introuvable pour ce slug' })
@@ -64,58 +65,77 @@ export default defineEventHandler(async (event) => {
 
   // If user placed an option or already paid, he is counted as a booked traveler, otherwise he is just assigned to the deal temporarily
   const bookedPlaceCount = (alreadyPaid > 0 || is_option === true) ? (booked_places || Number(nbTravelers)) : 0
-  // Insert into booked_dates
-  const { data: bookedDate, error } = await supabase
-    .from('booked_dates')
-    .insert([{
-      travel_date_id: dateId,
-      deal_id: dealId,
-      booked_places: bookedPlaceCount,
-      is_option: is_option || null,
-      expiracy_date: expiracy_date || null,
-    }])
-    .select('*')
-    .single()
-  if (bookedDate) {
-    console.log(`[assign-deal] Supabase insert OK bookedId=${bookedDate.id} dealId=${dealId} in ${Date.now() - startTime}ms`)
+
+  // UNIQUE(deal_id) : un deal = une ligne à vie. upsertBookedDateForDeal couvre
+  // les 4 cas — création, ré-assignation idempotente sur la même date (les 3
+  // retries du funnel), conflit avec une autre date, et résurrection d'une
+  // réservation supprimée.
+  const assignPatch = {
+    booked_places: bookedPlaceCount,
+    is_option: is_option === true, // était `is_option || null` : on n'écrit plus de NULL
+    expiracy_date: expiracy_date || null,
   }
-  const alreadyAssigned = error && error.message.includes('duplicate key value violates unique constraint')
-  if (alreadyAssigned) {
-    console.warn(`[assign-deal] Duplicate dealId=${dealId} dateId=${dateId}`)
-    const { data: existingBookedDate, error: existingError } = await supabase
-      .from('booked_dates')
-      .select('deal_id, travel_dates(id, travel_slug)')
-      .eq('deal_id', dealId)
-      .single()
-    if (existingError || !existingBookedDate?.travel_dates) {
-      throw createError({ statusCode: 409, statusMessage: 'Deal déjà assigné', data: { code: 'ASSIGN_DUPLICATE' } })
+  let res = await booking.upsertBookedDateForDeal(dealId, dateId, assignPatch, {
+    user: bookingUser,
+    allowMove: true,
+    resetOnRevive: true,
+  })
+
+  if (res.conflict === 'other_date') {
+    console.warn(`[assign-deal] Duplicate dealId=${dealId} dateId=${dateId} otherDate=${res.row.travel_date_id}`)
+    const { data: other } = await supabase
+      .from('travel_dates')
+      .select('id, travel_slug, deleted')
+      .eq('id', res.row.travel_date_id)
+      .maybeSingle()
+
+    if (other?.deleted) {
+      // La cascade de suppression de l'autre date a laissé cette réservation
+      // active : renvoyer l'opérateur vers une date supprimée serait pire que
+      // d'autoriser le déplacement. On prend la réservation et on alerte.
+      await slack.alertCascadeLeak({ dealId, bookedId: res.row.id, travelDateId: other.id })
+      res = await booking.upsertBookedDateForDeal(dealId, dateId, assignPatch, {
+        user: bookingUser,
+        allowMove: true,
+        resetOnRevive: true,
+        force: true,
+      })
     }
-    throw createError({
-      statusCode: 409,
-      statusMessage: 'Deal déjà assigné à une autre date',
-      data: {
-        code: 'ASSIGN_DUPLICATE_OTHER_DATE',
-        redirectTo: `/booking-management/${existingBookedDate.travel_dates.travel_slug}/${existingBookedDate.travel_dates.id}`,
-      },
-    })
-  }
-  else if (error) {
-    console.error(`[assign-deal] Supabase insert FAILED dealId=${dealId}`, error.message)
-    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'ASSIGN_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.insert' }, message: error.message })
+    else {
+      throw createError({
+        statusCode: 409,
+        statusMessage: other ? 'Deal déjà assigné à une autre date' : 'Deal déjà assigné',
+        data: other
+          ? { code: 'ASSIGN_DUPLICATE_OTHER_DATE', redirectTo: `/booking-management/${other.travel_slug}/${other.id}` }
+          : { code: 'ASSIGN_DUPLICATE' },
+      })
+    }
   }
 
-  // Update travel_dates.booked_seat
-  const { data: allBooked, error: sumError } = await supabase
-    .from('booked_dates')
-    .select('booked_places')
-    .eq('travel_date_id', dateId)
-  if (sumError) throw createError({ statusCode: 500, statusMessage: sumError.message })
-  const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
-  const recomputeRes = await booking.updateTravelDate(dateId, totalBooked)
-  if (recomputeRes?.error) throw createError({ statusCode: 500, statusMessage: recomputeRes.error })
+  if (res.error || !res.row) {
+    console.error(`[assign-deal] Supabase upsert FAILED dealId=${dealId}`, res.error)
+    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'ASSIGN_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.upsert' }, message: res.error || 'Upsert booked_dates sans résultat' })
+  }
+  const bookedDate = res.row
+  console.log(`[assign-deal] Supabase upsert OK bookedId=${bookedDate.id} dealId=${dealId} `
+    + `created=${res.created} revived=${res.revived} moved=${res.moved} in ${Date.now() - startTime}ms`)
+
+  // Update travel_dates.booked_seat — les DEUX dates quand la ligne a bougé.
+  const recomputeResults = await booking.recomputeManyBookedSeatAndStatus([dateId, res.previous?.travel_date_id])
+  const recomputeErr = recomputeResults.find(r => r?.error)
+  if (recomputeErr) throw createError({ statusCode: 500, statusMessage: recomputeErr.error })
+
+  // Si la ligne a quitté une autre date, celle-ci peut ne plus avoir de payant.
+  if (res.moved && res.previous?.travel_date_id) {
+    await departures.cleanupDepartureDealIfEmpty(res.previous.travel_date_id)
+  }
 
   // If the deal has already paid, sync it with the departure record deal (pipeline 4)
-  if (bookedPlaceCount > 0 && alreadyPaid > 0 && deal) {
+  // Conditionné à un vrai changement : sans ça les 3 retries du funnel
+  // resynchronisent le deal de départ trois fois.
+  const changed = res.created || res.revived || res.moved
+    || res.previous?.booked_places !== bookedPlaceCount
+  if (bookedPlaceCount > 0 && alreadyPaid > 0 && deal && changed) {
     await departures.handlePaymentForDeparture(bookedDate, deal.title, deal.contact)
   }
 
@@ -136,7 +156,35 @@ export default defineEventHandler(async (event) => {
   Object.assign(data_to_update, { paiementLink: `${origin}/checkout?type=balance&booked_id=${bookedDate.id}` })
   await activecampaign.updateDeal(dealId, data_to_update)
 
-  await logDateActivity(dateId, bookingUser, 'deal_assigned', { deal_id: dealId, booked_places: bookedPlaceCount })
+  // On ne journalise que si quelque chose a réellement changé, sinon chaque
+  // session du funnel écrit 3 lignes identiques dans date_activity_log.
+  if (res.revived) {
+    await logDateActivity(dateId, bookingUser, 'deal_restored', {
+      deal_id: dealId,
+      booked_id: bookedDate.id,
+      booked_places: bookedPlaceCount,
+      from_travel_date_id: res.previous?.travel_date_id || null,
+      previous_reason: res.previous?.deleted_reason || null,
+    })
+    if (res.moved && res.previous?.travel_date_id) {
+      await logDateActivity(res.previous.travel_date_id, bookingUser, 'deal_moved_out', {
+        deal_id: dealId, booked_id: bookedDate.id, to_travel_date_id: dateId,
+      })
+    }
+  }
+  else if (res.created) {
+    await logDateActivity(dateId, bookingUser, 'deal_assigned', { deal_id: dealId, booked_places: bookedPlaceCount })
+  }
+  else if (res.moved) {
+    await logDateActivity(dateId, bookingUser, 'deal_assigned', {
+      deal_id: dealId, booked_places: bookedPlaceCount, from_travel_date_id: res.previous?.travel_date_id || null,
+    })
+    if (res.previous?.travel_date_id) {
+      await logDateActivity(res.previous.travel_date_id, bookingUser, 'deal_moved_out', {
+        deal_id: dealId, booked_id: bookedDate.id, to_travel_date_id: dateId,
+      })
+    }
+  }
 
   console.log(`[assign-deal] DONE dealId=${dealId} bookedId=${bookedDate.id} totalTime=${Date.now() - startTime}ms`)
   return bookedDate

--- a/server/api/v1/booking/[slug]/date/[dateId]/assign-departure-deal.delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/assign-departure-deal.delete.js
@@ -10,15 +10,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id, travel_slug, departure_id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  const travelDate = await booking.requireActiveTravelDate(dateId, slug)
 
   const { error: updateError } = await supabase
     .from('travel_dates')

--- a/server/api/v1/booking/[slug]/date/[dateId]/assign-departure-deal.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/assign-departure-deal.post.js
@@ -15,15 +15,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Ensure the date exists and matches slug
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id, travel_slug, departure_id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug)
 
   // Update departure_id on the travel_dates row
   const { error: updateError } = await supabase

--- a/server/api/v1/booking/[slug]/date/[dateId]/attachments.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/attachments.get.js
@@ -1,4 +1,4 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -10,21 +10,20 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  // ?includeDeleted=true alimente la Corbeille du BMS.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
 
-  const { data, error } = await supabase
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
+
+  let query = supabase
     .from('date_attachments')
     .select('*')
     .eq('travel_date_id', dateId)
     .order('created_at', { ascending: false })
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message })

--- a/server/api/v1/booking/[slug]/date/[dateId]/attachments/[attachmentId].delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/attachments/[attachmentId].delete.js
@@ -15,6 +15,7 @@ console.log('bookingUser', bookingUser)
     .select('*')
     .eq('id', attachmentId)
     .eq('travel_date_id', dateId)
+    .eq('deleted', false)
     .single()
 
   if (fetchError || !attachment) {
@@ -25,22 +26,16 @@ console.log('bookingUser', bookingUser)
     throw createError({ statusCode: 403, statusMessage: 'Non autorisé à supprimer ce fichier' })
   }
 
-  const { error: storageError } = await supabase
-    .storage
-    .from('date-attachments')
-    .remove([attachment.storage_path])
+  // L'objet Storage n'est PAS supprimé : une pièce jointe restaurée doit
+  // retrouver son fichier, pas un 404. Le nettoyage du bucket relève du futur
+  // job de purge, qui devra vider le Storage avant de supprimer les lignes.
+  const removed = await softDelete.remove('date_attachments', q => q.eq('id', attachmentId), {
+    user: bookingUser,
+    reason: softDelete.REASONS.MANUAL,
+  })
 
-  if (storageError) {
-    console.error('Error deleting file from storage:', storageError)
-  }
-
-  const { error: deleteError } = await supabase
-    .from('date_attachments')
-    .delete()
-    .eq('id', attachmentId)
-
-  if (deleteError) {
-    throw createError({ statusCode: 500, statusMessage: deleteError.message })
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
   }
 
   return { success: true }

--- a/server/api/v1/booking/[slug]/date/[dateId]/attachments/upload-url.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/attachments/upload-url.post.js
@@ -37,15 +37,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Fichier trop volumineux (max 10 Mo)' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug)
 
   const sanitizedName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_')
   const storagePath = `${dateId}/${crypto.randomUUID()}-${sanitizedName}`

--- a/server/api/v1/booking/[slug]/date/[dateId]/booked.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/booked.get.js
@@ -1,4 +1,11 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
+
+// ⚠️ Cet endpoint SUPPRIMAIT en dur les réservations dont le deal AC ne
+// renvoyait pas d'email — y compris quand ActiveCampaign était simplement
+// injoignable, puisque le catch fabriquait `{ name: '', email: '' }`. Charger la
+// page BMS d'une date pendant une panne AC détruisait donc des réservations et
+// réécrivait booked_seat. Un GET ne mute plus rien : les lignes sans email sont
+// renvoyées avec `orphan: true` et l'opérateur décide.
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -10,20 +17,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
   // Ensure the date exists and matches slug (avoid returning wrong travelers list)
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
 
-  const { data, error } = await supabase
+  // ?includeDeleted=true : section « Voyageurs supprimés » du BMS.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
+
+  let query = supabase
     .from('booked_dates')
     .select('*')
     .eq('travel_date_id', dateId)
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message })
@@ -33,6 +39,7 @@ export default defineEventHandler(async (event) => {
   const travelers = await Promise.all((data || []).map(async (row) => {
     let contact = {}
     let customFields = {}
+    let acLookupFailed = false
     try {
       const deal = await activecampaign.getDealById(row.deal_id)
       customFields = await activecampaign.getDealCustomFields(row.deal_id)
@@ -55,12 +62,20 @@ export default defineEventHandler(async (event) => {
         }
       }
     }
-    catch {
+    catch (err) {
+      // On distingue « AC injoignable » de « deal réellement sans email » :
+      // c'est précisément cette confusion qui faisait perdre des réservations.
+      acLookupFailed = true
       contact = { name: '', email: '' }
+      console.error(`[booked.get] lookup AC échoué dealId=${row.deal_id}:`, err.message)
     }
     return {
       ...row,
       ...contact,
+      // Orpheline = le deal existe côté AC mais n'a pas d'email. Si le lookup a
+      // échoué, on ne sait rien : ce n'est pas une orpheline.
+      orphan: !acLookupFailed && !contact.email?.trim(),
+      acLookupFailed,
       nbTravelers: customFields.nbTravelers,
       alreadyPaid: customFields.alreadyPaid,
       restToPay: customFields.restToPay,
@@ -68,34 +83,5 @@ export default defineEventHandler(async (event) => {
     }
   }))
 
-  // Filter out travelers without email and delete their booked_dates entries
-  const validTravelers = []
-  const travelersToDelete = []
-
-  for (const traveler of travelers) {
-    if (traveler.email && traveler.email.trim() !== '') {
-      validTravelers.push(traveler)
-    }
-    else {
-      travelersToDelete.push(traveler.id)
-    }
-  }
-
-  // Delete booked_dates entries for travelers without email
-  if (travelersToDelete.length > 0) {
-    const { error: deleteError } = await supabase
-      .from('booked_dates')
-      .delete()
-      .in('id', travelersToDelete)
-
-    if (deleteError) {
-      console.error('Error deleting booked_dates entries:', deleteError)
-    }
-    else {
-      console.log(`Deleted ${travelersToDelete.length} booked_dates entries without valid email`)
-    }
-
-    await booking.recomputeBookedSeatAndStatus(dateId)
-  }
-  return validTravelers
+  return travelers
 })

--- a/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId].delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId].delete.js
@@ -7,35 +7,34 @@ export default defineEventHandler(async (event) => {
 
   const { bookedId } = event.context.params
 
-  // Fetch the row to get travel_date_id
+  // Fetch the row to get travel_date_id (contrat null | row)
   const bookedRow = await booking.retrieveBookedDateById(bookedId)
-  if (bookedRow.error || !bookedRow.deal_id) {
+  if (!bookedRow?.deal_id) {
     throw createError({ statusCode: 404, statusMessage: 'Impossible de trouver la réservation à supprimer.' })
   }
 
-  console.log('BMS: bookedRow =', bookedRow)
   const travel_date_id = bookedRow.travel_date_id
-  console.log(`BMS: Deleting booked reservation ${bookedId} for travel_date ${travel_date_id}`)
+  console.log(`BMS: soft delete de la réservation ${bookedId} sur la date ${travel_date_id}`)
 
-  const deletedBookedId = await booking.deleteBookedDateById(bookedId)
-  if (deletedBookedId.error) {
-    throw createError({ statusCode: 500, statusMessage: deletedBookedId.error })
+  const removed = await booking.softDeleteBookedDateById(bookedId, {
+    user: bookingUser,
+    reason: softDelete.REASONS.MANUAL,
+  })
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
   }
 
   // Update travel_dates.booked_seat
-  const allBooked = await booking.retrieveBookedPlacesByTravelDateId(travel_date_id)
-  if (allBooked.error) {
-    throw createError({ statusCode: 500, statusMessage: allBooked.error })
+  const recompute = await booking.recomputeBookedSeatAndStatus(travel_date_id)
+  if (recompute?.error) {
+    throw createError({ statusCode: 500, statusMessage: recompute.error })
   }
-
-  const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
-  await booking.updateTravelDate(travel_date_id, totalBooked)
 
   // Remove departure record deal if no paying clients remain
   await departures.cleanupDepartureDealIfEmpty(travel_date_id)
 
   await logDateActivity(travel_date_id, bookingUser, 'deal_removed', { deal_id: bookedRow.deal_id, booked_id: bookedId })
 
-  console.log(`BMS: Successfully deleted booked reservation ${bookedId}, updated total booked seats to ${totalBooked}`)
-  return { success: true }
+  console.log(`BMS: réservation ${bookedId} masquée, booked_seat recalculé à ${recompute.booked_seat}`)
+  return { success: true, booked_id: bookedId, booked_seat: recompute.booked_seat, status: recompute.status }
 })

--- a/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId]/restore.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId]/restore.post.js
@@ -1,0 +1,67 @@
+import { defineEventHandler, createError } from 'h3'
+
+// Restauration d'une réservation seule.
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { dateId, slug, bookedId } = event.context.params
+  if (!dateId || !slug || !bookedId) {
+    throw createError({ statusCode: 400, statusMessage: 'slug, dateId et bookedId requis' })
+  }
+
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
+
+  const bookedRow = await booking.retrieveBookedDateById(bookedId, { includeDeleted: true })
+  if (!bookedRow) {
+    throw createError({ statusCode: 404, statusMessage: 'Réservation introuvable' })
+  }
+  if (!bookedRow.deleted) {
+    return { success: true, alreadyActive: true, booked: bookedRow }
+  }
+
+  // La réservation peut avoir été déplacée depuis : on restaure là où elle
+  // pointe réellement, pas là où l'écran a été ouvert.
+  const targetDateId = bookedRow.travel_date_id
+
+  const { data: parent } = await supabase
+    .from('travel_dates')
+    .select('id, deleted')
+    .eq('id', targetDateId)
+    .maybeSingle()
+
+  if (parent?.deleted) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'La date de cette réservation est supprimée — restaurez la date d\'abord',
+      data: { code: 'RESTORE_PARENT_DELETED', travel_date_id: targetDateId },
+    })
+  }
+
+  const restored = await booking.restoreBookedDateById(bookedId)
+  if (restored.error) {
+    throw createError({ statusCode: 500, statusMessage: restored.error })
+  }
+
+  const recompute = await booking.recomputeBookedSeatAndStatus(targetDateId)
+  if (recompute?.error) {
+    throw createError({ statusCode: 500, statusMessage: recompute.error })
+  }
+
+  await logDateActivity(targetDateId, bookingUser, 'deal_restored', {
+    deal_id: bookedRow.deal_id,
+    booked_id: bookedId,
+    cause: 'manual_restore',
+    previous_reason: bookedRow.deleted_reason || null,
+  })
+
+  // On ne touche pas au deal de départ : s'il a été supprimé dans AC il n'est
+  // pas récupérable, et le recréer automatiquement spammerait le pipeline 4.
+  return {
+    success: true,
+    booked: restored.rows[0] || null,
+    recomputed: { travel_date_id: targetDateId, booked_seat: recompute.booked_seat, status: recompute.status },
+  }
+})

--- a/server/api/v1/booking/[slug]/date/[dateId]/duplicate.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/duplicate.post.js
@@ -15,6 +15,7 @@ export default defineEventHandler(async (event) => {
     .select('*')
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .single()
   if (error || !original) {
     throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
@@ -29,7 +30,15 @@ export default defineEventHandler(async (event) => {
   delete rest.status
   // Never carry over the departure deal — it belongs to the original date only
   delete rest.departure_id
-  const newDate = { ...rest, booked_seat: 0, status: 'soon_confirmed' }
+  // Ne jamais recopier la pierre tombale : `select('*')` ramène désormais les
+  // colonnes de soft delete, et dupliquer une date supprimée produirait une
+  // date invisible sans la moindre erreur.
+  delete rest.deleted
+  delete rest.deleted_at
+  delete rest.deleted_by
+  delete rest.deleted_reason
+  delete rest.deleted_batch
+  const newDate = { ...rest, booked_seat: 0, status: 'soon_confirmed', deleted: false }
 
   // Insert new row
   const { data: inserted, error: insertError } = await supabase

--- a/server/api/v1/booking/[slug]/date/[dateId]/index.delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/index.delete.js
@@ -1,53 +1,110 @@
 import { defineEventHandler, createError } from 'h3'
 
+// Suppression d'une date de départ : soft delete en cascade.
+//
+// Rien n'est effacé physiquement, ni les lignes ni les objets Storage. La
+// restauration (restore.post.js) remonte exactement les enfants portant
+// deleted_reason = 'cascade_travel_date'.
+
+const CHILD_TABLES = ['booked_dates', 'date_notes', 'date_attachments', 'date_invoices']
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
-  if (isProdEnv) requireBookingUser(event)
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
 
   const { dateId, slug } = event.context.params
   if (!dateId || !slug) {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
-  // Fetch the row to get travel_date_id
-  const { data: dateRow, error: fetchError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
 
-  if (fetchError || !dateRow) {
-    throw createError({
-      statusCode: 404,
-      statusMessage: 'Impossible de trouver la réservation à supprimer.',
-    })
-  }
-  const travel_date_id = dateRow.id
+  // 404 si la date n'existe pas, n'appartient pas à ce slug, ou est déjà supprimée.
+  const travelDate = await booking.requireActiveTravelDate(dateId, slug)
+  const batch = softDelete.newBatch()
 
-  // Delete every booked_dates first for this date
-  const { error: sumError } = await supabase
-    .from('booked_dates')
-    .delete()
-    .eq('travel_date_id', travel_date_id)
-  if (sumError) {
-    throw createError({
-      statusCode: 500,
-      statusMessage: sumError.message,
-    })
-  }
-
-  // Then Delete the row
-  const { error } = await supabase
-    .from('travel_dates')
-    .delete()
-    .eq('id', travel_date_id)
-  if (error) {
-    throw createError({
-      statusCode: 500,
-      statusMessage: error.message,
-    })
+  // 1. Deal de départ (pipeline 4).
+  //    cleanupDepartureDealIfEmpty ne suffit pas ici : il ne tire que s'il ne
+  //    reste aucune réservation payante, or la date disparaît quoi qu'il arrive.
+  //    Et surtout, travel_dates porte UNIQUE(departure_id) : un tombstone qui
+  //    garderait son departure_id squatterait ce deal AC à vie et ferait échouer
+  //    toute assignation future sur un 23505 opaque.
+  const previousDepartureId = travelDate.departure_id || null
+  if (previousDepartureId) {
+    try {
+      await activecampaign.deleteDeal(previousDepartureId)
+    }
+    catch (err) {
+      console.error('[date.delete] suppression du deal de départ AC échouée:', err.message)
+    }
+    const { error: clearError } = await supabase
+      .from('travel_dates')
+      .update({ departure_id: null })
+      .eq('id', dateId)
+    if (clearError) {
+      console.error('[date.delete] departure_id non remis à null:', clearError)
+    }
   }
 
-  return { success: true }
+  // 2. Les enfants D'ABORD, le parent ENSUITE.
+  //    La cascade n'est pas transactionnelle (appels PostgREST successifs). Cet
+  //    ordre fait qu'une exécution partielle ressemble à « enfants trop
+  //    supprimés » — que le prochain recomputeBookedSeatAndStatus corrige — et
+  //    non à « enfants vivants sous une date morte ».
+  //    softDelete.remove() filtre sur deleted = false : les lignes déjà
+  //    supprimées à la main gardent leur raison 'manual' et ne remonteront donc
+  //    pas lors d'une restauration. C'est voulu.
+  const softDeleted = {}
+  for (const table of CHILD_TABLES) {
+    const res = await softDelete.remove(table, q => q.eq('travel_date_id', dateId), {
+      user: bookingUser,
+      reason: softDelete.REASONS.CASCADE_TRAVEL_DATE,
+      batch,
+      select: table === 'booked_dates' ? 'id, deal_id, booked_places' : 'id',
+    })
+    if (res.error) {
+      throw createError({ statusCode: 500, statusMessage: `${table}: ${res.error}` })
+    }
+    softDeleted[table] = res.count
+    if (table === 'booked_dates') softDeleted.deal_ids = res.rows.map(r => r.deal_id)
+  }
+
+  // 3. Le parent. On ne remet PAS booked_seat à 0 : la restauration doit être
+  //    exacte, et toutes les lectures filtrent déjà les dates supprimées.
+  const removed = await softDelete.remove('travel_dates', q => q.eq('id', dateId), {
+    user: bookingUser,
+    reason: softDelete.REASONS.MANUAL,
+    batch,
+    select: 'id, deleted_at',
+  })
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
+  }
+  if (!removed.count) {
+    // Course avec une autre suppression concurrente.
+    throw createError({ statusCode: 409, statusMessage: 'Cette date vient d\'être supprimée par ailleurs' })
+  }
+
+  await logDateActivity(dateId, bookingUser, 'date_deleted', {
+    batch,
+    departure_id: previousDepartureId,
+    counts: {
+      booked_dates: softDeleted.booked_dates,
+      date_notes: softDeleted.date_notes,
+      date_attachments: softDeleted.date_attachments,
+      date_invoices: softDeleted.date_invoices,
+    },
+    deal_ids: softDeleted.deal_ids,
+  })
+
+  return {
+    success: true,
+    batch,
+    deletedAt: removed.rows[0]?.deleted_at || null,
+    softDeleted: {
+      booked_dates: softDeleted.booked_dates,
+      date_notes: softDeleted.date_notes,
+      date_attachments: softDeleted.date_attachments,
+      date_invoices: softDeleted.date_invoices,
+    },
+  }
 })

--- a/server/api/v1/booking/[slug]/date/[dateId]/invoices.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/invoices.get.js
@@ -1,4 +1,4 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -10,21 +10,20 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  // ?includeDeleted=true alimente la Corbeille du BMS.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
 
-  const { data, error } = await supabase
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
+
+  let query = supabase
     .from('date_invoices')
     .select('*')
     .eq('travel_date_id', dateId)
     .order('created_at', { ascending: false })
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message })

--- a/server/api/v1/booking/[slug]/date/[dateId]/invoices/[invoiceId].delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/invoices/[invoiceId].delete.js
@@ -15,6 +15,7 @@ export default defineEventHandler(async (event) => {
     .select('*')
     .eq('id', invoiceId)
     .eq('travel_date_id', dateId)
+    .eq('deleted', false)
     .single()
 
   if (fetchError || !invoice) {
@@ -25,26 +26,15 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Non autorisé à supprimer cette facture' })
   }
 
-  // Only attempt storage removal for invoices that have an attached file —
-  // exception-case rows (no file) have no storage_path.
-  if (invoice.storage_path) {
-    const { error: storageError } = await supabase
-      .storage
-      .from('date-invoices')
-      .remove([invoice.storage_path])
+  // Le PDF reste dans le bucket : une facture restaurée porte des montants
+  // comptables et doit retrouver sa pièce justificative.
+  const removed = await softDelete.remove('date_invoices', q => q.eq('id', invoiceId), {
+    user: bookingUser,
+    reason: softDelete.REASONS.MANUAL,
+  })
 
-    if (storageError) {
-      console.error('Error deleting invoice from storage:', storageError)
-    }
-  }
-
-  const { error: deleteError } = await supabase
-    .from('date_invoices')
-    .delete()
-    .eq('id', invoiceId)
-
-  if (deleteError) {
-    throw createError({ statusCode: 500, statusMessage: deleteError.message })
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
   }
 
   return { success: true }

--- a/server/api/v1/booking/[slug]/date/[dateId]/invoices/index.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/invoices/index.post.js
@@ -23,15 +23,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Sanity-check the date belongs to this slug.
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug)
 
   const { data: invoice, error: insertError } = await supabase
     .from('date_invoices')

--- a/server/api/v1/booking/[slug]/date/[dateId]/invoices/upload-url.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/invoices/upload-url.post.js
@@ -40,15 +40,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Fichier trop volumineux (max 10 Mo)' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug)
 
   const sanitizedName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_')
   const storagePath = `${dateId}/${crypto.randomUUID()}-${sanitizedName}`

--- a/server/api/v1/booking/[slug]/date/[dateId]/kickstart.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/kickstart.post.js
@@ -24,6 +24,7 @@ export default defineEventHandler(async (event) => {
     .select('id, travel_slug')
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .single()
   if (travelDateError || !travelDate) {
     throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'KICKSTART_DATE_NOT_FOUND', step: 'details', origin: { field: 'dateId', received: dateId }, message: 'Date introuvable pour ce slug' })
@@ -41,16 +42,22 @@ export default defineEventHandler(async (event) => {
     throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'KICKSTART_CREATE_DEAL_FAILED', step: 'details', origin: { endpoint: 'activecampaign.createMinimalDeal' }, message: 'Erreur lors de la création du deal' })
   }
 
-  // 3. Insert into booked_dates (booked_places=0 — not counted as reserved until payment)
-  const { data: bookedDate, error: bookedError } = await supabase
-    .from('booked_dates')
-    .insert([{ travel_date_id: dateId, deal_id: dealId, booked_places: 0 }])
-    .select('*')
-    .single()
-  if (bookedError) {
-    console.error('[kickstart] Supabase insert failed', bookedError.message)
-    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'KICKSTART_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.insert' }, message: bookedError.message })
+  // 3. Upsert into booked_dates (booked_places=0 — not counted as reserved until payment)
+  // Le deal vient d'être créé, donc une collision sur UNIQUE(deal_id) est
+  // théoriquement impossible ; passer par le helper rend quand même l'appel
+  // immunisé à un retry d'id côté AC et à la course avec le `enrich`
+  // fire-and-forget — et ressuscite une éventuelle réservation supprimée au
+  // lieu d'échouer sur une contrainte d'unicité, ce que faisait l'INSERT nu.
+  const res = await booking.upsertBookedDateForDeal(dealId, dateId, { booked_places: 0 }, {
+    user: null,
+    allowMove: true,
+    resetOnRevive: true,
+  })
+  if (res.error || !res.row) {
+    console.error('[kickstart] Supabase upsert failed', res.error)
+    throw funnelReporter.funnelCreateError({ statusCode: 500, code: 'KICKSTART_SUPABASE_INSERT_FAILED', step: 'details', origin: { endpoint: 'booked_dates.upsert' }, message: res.error || 'Upsert booked_dates sans résultat' })
   }
+  const bookedDate = res.row
   lap(`booked_dates inserted bookedId=${bookedDate.id}`)
 
   // 4. Fire-and-forget enrichment — use the request origin so this works in dev and prod

--- a/server/api/v1/booking/[slug]/date/[dateId]/margin-override.put.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/margin-override.put.js
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
     .select('id, margin_override_per_traveler, real_traveler_count_override')
     .eq('id', dateId)
     .eq('travel_slug', slug)
+    .eq('deleted', false)
     .single()
 
   if (existingError || !existing) {

--- a/server/api/v1/booking/[slug]/date/[dateId]/margin.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/margin.get.js
@@ -11,16 +11,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Sanity-check the date belongs to this slug.
-  const { data: travelDate, error: tdError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-
-  if (tdError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
 
   try {
     const breakdown = await margins.computeMarginForDate(dateId)

--- a/server/api/v1/booking/[slug]/date/[dateId]/notes.get.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/notes.get.js
@@ -1,4 +1,4 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -10,21 +10,20 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  // ?includeDeleted=true alimente la Corbeille du BMS.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
 
-  const { data, error } = await supabase
+  await booking.requireActiveTravelDate(dateId, slug, { includeDeleted: true })
+
+  let query = supabase
     .from('date_notes')
     .select('*')
     .eq('travel_date_id', dateId)
     .order('created_at', { ascending: true })
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query
 
   if (error) {
     throw createError({ statusCode: 500, statusMessage: error.message })

--- a/server/api/v1/booking/[slug]/date/[dateId]/notes.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/notes.post.js
@@ -15,15 +15,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Le contenu est requis' })
   }
 
-  const { data: travelDate, error: travelDateError } = await supabase
-    .from('travel_dates')
-    .select('id')
-    .eq('id', dateId)
-    .eq('travel_slug', slug)
-    .single()
-  if (travelDateError || !travelDate) {
-    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
-  }
+  await booking.requireActiveTravelDate(dateId, slug)
 
   const { data, error } = await supabase
     .from('date_notes')

--- a/server/api/v1/booking/[slug]/date/[dateId]/notes/[noteId].delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/notes/[noteId].delete.js
@@ -15,6 +15,7 @@ export default defineEventHandler(async (event) => {
     .select('*')
     .eq('id', noteId)
     .eq('travel_date_id', dateId)
+    .eq('deleted', false)
     .single()
 
   if (noteError || !note) {
@@ -25,13 +26,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Non autorisé à supprimer cette note' })
   }
 
-  const { error } = await supabase
-    .from('date_notes')
-    .delete()
-    .eq('id', noteId)
+  const removed = await softDelete.remove('date_notes', q => q.eq('id', noteId), {
+    user: bookingUser,
+    reason: softDelete.REASONS.MANUAL,
+  })
 
-  if (error) {
-    throw createError({ statusCode: 500, statusMessage: error.message })
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
   }
 
   return { success: true }

--- a/server/api/v1/booking/[slug]/date/[dateId]/restore-child.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/restore-child.post.js
@@ -1,0 +1,55 @@
+import { defineEventHandler, createError, readBody } from 'h3'
+
+// Restauration d'une note / pièce jointe / facture supprimée.
+// Un seul endpoint pour les trois ressources à faible risque, plutôt que trois
+// fichiers quasi identiques.
+
+const RESOURCES = {
+  note: 'date_notes',
+  attachment: 'date_attachments',
+  invoice: 'date_invoices',
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { dateId, slug } = event.context.params
+  const { resource, id } = await readBody(event)
+
+  if (!dateId || !slug) {
+    throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
+  }
+  const table = RESOURCES[resource]
+  if (!table) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `resource doit valoir ${Object.keys(RESOURCES).join(', ')}`,
+    })
+  }
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'id requis' })
+  }
+
+  // La date parente doit être active : restaurer une note sous une date
+  // supprimée la rendrait invisible de toute façon.
+  await booking.requireActiveTravelDate(dateId, slug)
+
+  // Le filtre sur travel_date_id empêche de restaurer une ressource d'une
+  // autre date en passant son id.
+  const restored = await softDelete.restore(table, q => q
+    .eq('id', id)
+    .eq('travel_date_id', dateId), { select: '*' })
+
+  if (restored.error) {
+    throw createError({ statusCode: 500, statusMessage: restored.error })
+  }
+  if (!restored.count) {
+    throw createError({ statusCode: 404, statusMessage: 'Élément supprimé introuvable pour cette date' })
+  }
+
+  await logDateActivity(dateId, bookingUser, 'child_restored', { resource, id })
+
+  return { success: true, resource, item: restored.rows[0] }
+})

--- a/server/api/v1/booking/[slug]/date/[dateId]/restore.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/restore.post.js
@@ -1,0 +1,138 @@
+import { defineEventHandler, createError } from 'h3'
+
+// Restauration d'une date supprimée + de ses enfants en cascade.
+//
+// On ne remonte QUE les enfants portant deleted_reason = 'cascade_travel_date'.
+// Une réservation que l'opérateur avait supprimée individuellement AVANT la
+// suppression de la date garde la raison 'manual' (softDelete.remove() filtre
+// sur deleted = false et n'écrase donc jamais un tombstone existant) et reste
+// supprimée — c'est le comportement attendu.
+
+const CHILD_TABLES = ['booked_dates', 'date_notes', 'date_attachments', 'date_invoices']
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { dateId, slug } = event.context.params
+  if (!dateId || !slug) {
+    throw createError({ statusCode: 400, statusMessage: 'slug et dateId requis' })
+  }
+
+  const { data: travelDate, error: fetchError } = await supabase
+    .from('travel_dates')
+    .select('*')
+    .eq('id', dateId)
+    .eq('travel_slug', slug)
+    .eq('deleted', true)
+    .maybeSingle()
+
+  if (fetchError || !travelDate) {
+    throw createError({ statusCode: 404, statusMessage: 'Aucune date supprimée à restaurer pour ce slug' })
+  }
+
+  // --- Détection de conflits, AVANT toute écriture -------------------------
+  // Point clé : une réservation dont le deal a été ré-assigné ailleurs ne PEUT
+  // pas être ressuscitée par erreur. UNIQUE(deal_id) fait que la ré-assignation
+  // a ressuscité cette même ligne physique et changé son travel_date_id, donc
+  // le filtre de restauration ci-dessous l'exclut déjà. Le filtre s'auto-protège
+  // — mais il faut quand même le signaler à l'opérateur.
+  const conflicts = []
+  const { data: logRows } = await supabase
+    .from('date_activity_log')
+    .select('changes')
+    .eq('travel_date_id', dateId)
+    .eq('action', 'date_deleted')
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  const dealIds = logRows?.[0]?.changes?.deal_ids || []
+  if (dealIds.length) {
+    const { data: movedRows } = await supabase
+      .from('booked_dates')
+      .select('id, deal_id, travel_date_id, deleted, travel_dates(travel_slug)')
+      .in('deal_id', dealIds)
+    for (const row of movedRows || []) {
+      if (row.travel_date_id !== dateId || row.deleted === false) {
+        conflicts.push({
+          type: 'booking_reassigned',
+          deal_id: row.deal_id,
+          booked_id: row.id,
+          travel_date_id: row.travel_date_id,
+          travel_slug: row.travel_dates?.travel_slug || null,
+        })
+      }
+    }
+  }
+
+  // Avertissement (non bloquant) : une date active a été créée entre-temps pour
+  // le même voyage au même départ.
+  const { data: twin } = await supabase
+    .from('travel_dates')
+    .select('id')
+    .eq('travel_slug', travelDate.travel_slug)
+    .eq('departure_date', travelDate.departure_date)
+    .eq('deleted', false)
+    .maybeSingle()
+  if (twin) {
+    conflicts.push({ type: 'duplicate_active_date', travel_date_id: twin.id, travel_slug: travelDate.travel_slug })
+  }
+
+  // --- Restauration -------------------------------------------------------
+  const restoredParent = await softDelete.restore('travel_dates', q => q.eq('id', dateId))
+  if (restoredParent.error) {
+    throw createError({ statusCode: 500, statusMessage: restoredParent.error })
+  }
+
+  const restored = {}
+  for (const table of CHILD_TABLES) {
+    const res = await softDelete.restore(table, q => q
+      .eq('travel_date_id', dateId)
+      .eq('deleted_reason', softDelete.REASONS.CASCADE_TRAVEL_DATE), {
+      select: table === 'booked_dates' ? 'id, deal_id, booked_places' : 'id',
+    })
+    if (res.error) {
+      throw createError({ statusCode: 500, statusMessage: `${table}: ${res.error}` })
+    }
+    restored[table] = res.count
+    if (table === 'booked_dates') restored.booked_rows = res.rows
+  }
+
+  // booked_seat est périmé depuis la suppression : recalcul obligatoire.
+  const recompute = await booking.recomputeBookedSeatAndStatus(dateId)
+  if (recompute?.error) {
+    throw createError({ statusCode: 500, statusMessage: recompute.error })
+  }
+
+  // Le deal de départ (pipeline 4) a été supprimé dans AC et n'est pas
+  // récupérable. On ne le recrée PAS automatiquement — ça spammerait le
+  // pipeline 4 à chaque restauration. Le BMS propose un bouton câblé sur
+  // l'endpoint assign-departure-deal existant.
+  const departureDealNeedsRecreation = (restored.booked_rows || [])
+    .some(r => Number(r.booked_places || 0) > 0)
+
+  await logDateActivity(dateId, bookingUser, 'date_restored', {
+    restored: {
+      booked_dates: restored.booked_dates,
+      date_notes: restored.date_notes,
+      date_attachments: restored.date_attachments,
+      date_invoices: restored.date_invoices,
+    },
+    conflicts,
+  })
+
+  return {
+    success: true,
+    restored: {
+      booked_dates: restored.booked_dates,
+      date_notes: restored.date_notes,
+      date_attachments: restored.date_attachments,
+      date_invoices: restored.date_invoices,
+    },
+    conflicts,
+    departureDealNeedsRecreation,
+    booked_seat: recompute.booked_seat,
+    status: recompute.status,
+  }
+})

--- a/server/api/v1/booking/[slug]/dates.get.js
+++ b/server/api/v1/booking/[slug]/dates.get.js
@@ -1,4 +1,4 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const { slug } = event.context.params
@@ -9,11 +9,19 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { data, error } = await supabase
+  // ?includeDeleted=true alimente la Corbeille du BMS. Par défaut on ne renvoie
+  // que les dates actives.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
+
+  let query = supabase
     .from('travel_dates')
     .select('*')
     .eq('travel_slug', slug)
     .order('departure_date', { ascending: true })
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query
 
   // console.log('SUPABASE RETURN: ', data, ' -- error: ', error)
   if (error) {

--- a/server/api/v1/booking/all-dates.get.js
+++ b/server/api/v1/booking/all-dates.get.js
@@ -10,6 +10,7 @@ export default defineEventHandler(async (event) => {
   const { data, error } = await supabase
     .from('travel_dates')
     .select('id, travel_slug, departure_date, return_date, departure_id, booked_seat, max_travelers, published, status, displayed_status')
+    .eq('deleted', false)
     .gte('booked_seat', 1)
     .gte('departure_date', now)
     .order('departure_date', { ascending: true })

--- a/server/api/v1/booking/booked_date/extend-option.post.js
+++ b/server/api/v1/booking/booked_date/extend-option.post.js
@@ -18,6 +18,7 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('is_option, expiracy_date')
     .eq('id', body.id)
+    .eq('deleted', false)
     .single()
   if (bookedDateError || !bookedDate) {
     throw createError({ statusCode: 404, statusMessage: bookedDateError?.message || 'Réservation introuvable' })

--- a/server/api/v1/booking/booked_date/option.post.js
+++ b/server/api/v1/booking/booked_date/option.post.js
@@ -14,6 +14,7 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('is_option, travel_date_id')
     .eq('id', body.id)
+    .eq('deleted', false)
     .single()
   if (bookedDateError || !bookedDate) {
     throw funnelReporter.funnelCreateError({ statusCode: 404, code: 'OPTION_BOOKED_DATE_NOT_FOUND', step: 'option_booking', origin: { field: 'id', received: body.id }, message: bookedDateError?.message || 'Réservation introuvable' })
@@ -34,14 +35,9 @@ export default defineEventHandler(async (event) => {
       .select('*')
       .single()
 
-    // Update travel_dates.booked_seat
-    const { data: allBooked, error: sumError } = await supabase
-      .from('booked_dates')
-      .select('booked_places')
-      .eq('travel_date_id', bookedDate.travel_date_id)
-    if (sumError) throw createError({ statusCode: 500, statusMessage: sumError.message })
-    const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
-    const recomputeRes = await booking.updateTravelDate(bookedDate.travel_date_id, totalBooked)
+    // Update travel_dates.booked_seat — via le helper, seul endroit qui filtre
+    // les réservations supprimées.
+    const recomputeRes = await booking.recomputeBookedSeatAndStatus(bookedDate.travel_date_id)
     if (recomputeRes?.error) throw createError({ statusCode: 500, statusMessage: recomputeRes.error })
 
     if (error) throw createError({ statusCode: 500, statusMessage: error.message })

--- a/server/api/v1/booking/booking-exists.js
+++ b/server/api/v1/booking/booking-exists.js
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('deal_id')
     .eq('id', booked_id)
+    .eq('deleted', false)
     .single()
 
   if (supabaseError || !bookedDate) {

--- a/server/api/v1/booking/date/[dateId].get.js
+++ b/server/api/v1/booking/date/[dateId].get.js
@@ -1,7 +1,11 @@
-import { defineEventHandler, createError } from 'h3'
+import { defineEventHandler, createError, getQuery } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const { dateId } = event.context.params
+  // ?includeDeleted=true : l'écran de restauration du BMS doit pouvoir charger
+  // une date supprimée. Le funnel public, lui, ne doit jamais la voir.
+  const { includeDeleted } = getQuery(event)
+  const withDeleted = includeDeleted === 'true' || includeDeleted === '1'
   if (!dateId) {
     throw funnelReporter.funnelCreateError({
       statusCode: 400,
@@ -11,11 +15,13 @@ export default defineEventHandler(async (event) => {
       message: 'dateId requis',
     })
   }
-  const { data, error } = await supabase
+  let query = supabase
     .from('travel_dates')
     .select('*')
     .eq('id', dateId)
-    .single()
+  if (!withDeleted) query = query.eq('deleted', false)
+
+  const { data, error } = await query.single()
 
   if (error || !data) {
     throw funnelReporter.funnelCreateError({

--- a/server/api/v1/booking/margins/[slug].delete.js
+++ b/server/api/v1/booking/margins/[slug].delete.js
@@ -3,7 +3,7 @@ import { defineEventHandler, getQuery, createError } from 'h3'
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
-  if (isProdEnv) requireBookingUser(event)
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
 
   const { slug } = event.context.params
   if (!slug) {
@@ -22,22 +22,23 @@ export default defineEventHandler(async (event) => {
   // default row when season_id is omitted. The default scope removes the whole
   // pax tier for the year (every season + the default), which is what the
   // editor's row trash icon means by "supprimer le palier".
-  let query = supabase
-    .from('voyage_margins')
-    .delete()
-    .eq('voyage_slug', slug)
-    .eq('pax', Number(pax))
-    .eq('year', Number(year))
+  // Soft delete : la ligne reste, mais margins.upsertMarginForVoyage lève la
+  // pierre tombale (...softDelete.clear()) dès qu'une valeur est ressaisie, donc
+  // retaper une marge « remarche » sans étape de restauration explicite.
+  const removed = await softDelete.remove('voyage_margins', (query) => {
+    let q = query
+      .eq('voyage_slug', slug)
+      .eq('pax', Number(pax))
+      .eq('year', Number(year))
+    if (scope === 'cell') {
+      q = seasonId ? q.eq('season_id', seasonId) : q.is('season_id', null)
+    }
+    return q
+  }, { user: bookingUser, reason: softDelete.REASONS.MANUAL })
 
-  if (scope === 'cell') {
-    query = seasonId ? query.eq('season_id', seasonId) : query.is('season_id', null)
+  if (removed.error) {
+    throw createError({ statusCode: 500, statusMessage: removed.error })
   }
 
-  const { error } = await query
-
-  if (error) {
-    throw createError({ statusCode: 500, statusMessage: error.message })
-  }
-
-  return { success: true }
+  return { success: true, softDeleted: removed.count }
 })

--- a/server/api/v1/booking/margins/dashboard/[slug].get.js
+++ b/server/api/v1/booking/margins/dashboard/[slug].get.js
@@ -74,7 +74,8 @@ export default defineEventHandler(async (event) => {
     supabase
       .from('voyage_margins')
       .select('pax, margin_per_traveler, year, season_id')
-      .eq('voyage_slug', slug),
+      .eq('voyage_slug', slug)
+      .eq('deleted', false),
     margins.getSeasonsForVoyage(slug),
     margins.getSettingsForVoyage(slug),
   ])

--- a/server/api/v1/booking/margins/index.get.js
+++ b/server/api/v1/booking/margins/index.get.js
@@ -28,7 +28,7 @@ export default defineEventHandler(async (event) => {
 
   const [marginRows, seasonRows, settingsRows, travelDates] = await Promise.all([
     fetchAllPaginated(() =>
-      supabase.from('voyage_margins').select('voyage_slug, pax, year, season_id, margin_per_traveler'),
+      supabase.from('voyage_margins').select('voyage_slug, pax, year, season_id, margin_per_traveler').eq('deleted', false),
     ),
     fetchAllPaginated(() =>
       supabase.from('voyage_margin_seasons').select('id, voyage_slug, label, sort_order'),

--- a/server/api/v1/booking/purchase-data.get.js
+++ b/server/api/v1/booking/purchase-data.get.js
@@ -32,6 +32,7 @@ export default defineEventHandler(async (event) => {
       .from('booked_dates')
       .select('deal_id, is_option')
       .eq('id', booked_id)
+      .eq('deleted', false)
       .single()
     console.log('bookedDate', bookedDate)
     if (bookedError || !bookedDate) {

--- a/server/api/v1/booking/trash.get.js
+++ b/server/api/v1/booking/trash.get.js
@@ -1,0 +1,107 @@
+import { defineEventHandler, getQuery, createError } from 'h3'
+
+// Corbeille du BMS : tout ce qui est soft-deleted, sur les trois tables qui
+// portent des données métier restaurables.
+//
+// Voir supabase/migrations/20260801090000_soft_delete.sql et
+// server/utils/softDelete.js. Les colonnes d'audit (deleted_at / deleted_by /
+// deleted_reason) sont renvoyées telles quelles : c'est ce qui permet à
+// l'opérateur de comprendre POURQUOI une ligne a disparu (action manuelle,
+// cascade d'une date, deal passé « Perdu » côté ActiveCampaign…).
+
+const MAX_ROWS = 200
+
+const AUDIT = 'deleted, deleted_at, deleted_by, deleted_reason, deleted_batch'
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  if (isProdEnv) requireBookingUser(event)
+
+  const { type = 'all', limit } = getQuery(event)
+  const max = Math.min(Number(limit) || MAX_ROWS, MAX_ROWS)
+  const wants = t => type === 'all' || type === t
+
+  const result = { travel_dates: [], booked_dates: [], deals: [] }
+
+  // --- travel_dates ------------------------------------------------------
+  if (wants('travel_dates')) {
+    const { data, error } = await supabase
+      .from('travel_dates')
+      .select(`id, travel_slug, departure_date, return_date, booked_seat, max_travelers, published, ${AUDIT}`)
+      .eq('deleted', true)
+      .order('deleted_at', { ascending: false })
+      .limit(max)
+    if (error) throw createError({ statusCode: 500, statusMessage: error.message })
+    result.travel_dates = data || []
+  }
+
+  // --- booked_dates ------------------------------------------------------
+  // L'embed travel_dates(...) sert à deux choses : afficher le voyage concerné,
+  // et savoir si la date parente est elle-même supprimée — auquel cas la
+  // restauration de la réservation seule est refusée (409 RESTORE_PARENT_DELETED),
+  // il faut restaurer la date d'abord.
+  if (wants('booked_dates')) {
+    const { data, error } = await supabase
+      .from('booked_dates')
+      .select(`id, deal_id, travel_date_id, booked_places, is_option, payment_type, ${AUDIT}, travel_dates(id, travel_slug, departure_date, deleted)`)
+      .eq('deleted', true)
+      .order('deleted_at', { ascending: false })
+      .limit(max)
+    if (error) throw createError({ statusCode: 500, statusMessage: error.message })
+
+    // Pas de FK entre booked_dates.deal_id et activecampaign_deals.id : PostgREST
+    // ne peut pas inférer la relation, on joint à la main (même approche que
+    // server/utils/margins.js).
+    const rows = data || []
+    const dealIds = [...new Set(rows.map(r => r.deal_id).filter(Boolean))]
+    const dealsById = new Map()
+    if (dealIds.length) {
+      const { data: deals } = await supabase
+        .from('activecampaign_deals')
+        .select('id, title, status, total_value, deleted')
+        .in('id', dealIds)
+      for (const d of deals || []) dealsById.set(Number(d.id), d)
+    }
+
+    result.booked_dates = rows.map((r) => {
+      const deal = dealsById.get(Number(r.deal_id)) || null
+      return {
+        ...r,
+        travel_slug: r.travel_dates?.travel_slug || null,
+        departure_date: r.travel_dates?.departure_date || null,
+        parent_deleted: r.travel_dates?.deleted === true,
+        deal_title: deal?.title || null,
+        deal_status: deal?.status || null,
+        deal_total_value: deal?.total_value ?? null,
+        deal_deleted: deal?.deleted === true,
+      }
+    })
+  }
+
+  // --- activecampaign_deals (miroir) -------------------------------------
+  if (wants('deals')) {
+    const { data, error } = await supabase
+      .from('activecampaign_deals')
+      .select(`id, title, status, stage, pipeline_id, pipeline_title, seller, total_value, slug, contact, ${AUDIT}`)
+      .eq('deleted', true)
+      .order('deleted_at', { ascending: false })
+      .limit(max)
+    if (error) throw createError({ statusCode: 500, statusMessage: error.message })
+    result.deals = data || []
+  }
+
+  return {
+    ...result,
+    counts: {
+      travel_dates: result.travel_dates.length,
+      booked_dates: result.booked_dates.length,
+      deals: result.deals.length,
+    },
+    truncated: {
+      travel_dates: result.travel_dates.length >= max,
+      booked_dates: result.booked_dates.length >= max,
+      deals: result.deals.length >= max,
+    },
+  }
+})

--- a/server/api/v1/booking/trash/deal/[dealId]/restore.post.js
+++ b/server/api/v1/booking/trash/deal/[dealId]/restore.post.js
@@ -1,0 +1,52 @@
+import { defineEventHandler, createError } from 'h3'
+
+// Restauration d'une ligne miroir activecampaign_deals.
+//
+// Portée volontairement limitée au miroir de reporting : on ne ressuscite PAS
+// la réservation liée au passage. Les deux vivent dans la corbeille comme deux
+// entrées distinctes, parce que ce sont deux décisions différentes — remettre un
+// deal dans les dashboards n'implique pas de réoccuper une place sur un départ.
+// La réponse signale quand une réservation supprimée existe encore pour ce deal,
+// pour que l'opérateur enchaîne s'il le souhaite.
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  const bookingUser = isProdEnv ? requireBookingUser(event) : getBookingUserOrNull(event)
+
+  const { dealId } = event.context.params
+  if (!dealId) {
+    throw createError({ statusCode: 400, statusMessage: 'dealId requis' })
+  }
+
+  const restored = await softDelete.restore('activecampaign_deals', q => q.eq('id', dealId), {
+    select: 'id, title, status, pipeline_title, total_value',
+  })
+  if (restored.error) {
+    throw createError({ statusCode: 500, statusMessage: restored.error })
+  }
+  if (!restored.count) {
+    throw createError({ statusCode: 404, statusMessage: 'Aucun deal supprimé à restaurer pour cet identifiant' })
+  }
+
+  // Réservation encore en corbeille pour ce deal ? On informe sans agir.
+  const booked = await booking.retrieveBookedDateByDealId(dealId, { includeDeleted: true })
+  const bookedStillDeleted = booked?.deleted === true
+
+  if (bookedStillDeleted && booked.travel_date_id) {
+    await logDateActivity(booked.travel_date_id, bookingUser, 'deal_mirror_restored', {
+      deal_id: Number(dealId),
+      booked_id: booked.id,
+      note: 'ligne miroir restaurée, réservation toujours supprimée',
+    })
+  }
+
+  return {
+    success: true,
+    deal: restored.rows[0] || null,
+    bookedStillDeleted,
+    booked: bookedStillDeleted
+      ? { id: booked.id, travel_date_id: booked.travel_date_id, deleted_reason: booked.deleted_reason }
+      : null,
+  }
+})

--- a/server/api/v1/booking/travel-dates.get.js
+++ b/server/api/v1/booking/travel-dates.get.js
@@ -56,6 +56,7 @@ export default defineEventHandler(async (event) => {
     .from('travel_dates')
     .select('travel_slug, booked_seat, displayed_booked_seat, departure_date, return_date, early_bird, last_minute, starting_price, max_travelers, min_travelers, status, displayed_status, displayed_badges')
     .or(orFilters)
+    .eq('deleted', false)
     .eq('published', true)
     .eq('is_custom_travel', false)
     // Extra global guard to keep the scanned set small (even though each OR branch already has its own gte threshold)

--- a/server/api/v1/booking/travelers-count.get.js
+++ b/server/api/v1/booking/travelers-count.get.js
@@ -20,6 +20,7 @@ export default defineEventHandler(async (event) => {
     .from('travel_dates')
     .select('id, travel_slug')
     .in('travel_slug', slugList)
+    .eq('deleted', false)
 
   if (tdError) {
     console.error('travelers-count travel_dates error', tdError)

--- a/server/api/v1/booking/travels-by-date.get.js
+++ b/server/api/v1/booking/travels-by-date.get.js
@@ -14,6 +14,7 @@ export default defineEventHandler(async () => {
   const { data, error } = await supabase
     .from('travel_dates')
     .select('travel_slug, booked_seat, displayed_booked_seat, departure_date, return_date, early_bird, last_minute, starting_price, max_travelers, min_travelers, status, displayed_status, displayed_badges')
+    .eq('deleted', false)
     .eq('published', true)
     .eq('is_custom_travel', false)
     .gte('departure_date', new Date().toISOString())

--- a/server/api/v1/booking/travels.get.js
+++ b/server/api/v1/booking/travels.get.js
@@ -8,6 +8,7 @@ export default defineEventHandler(async (event) => {
   const { data, error } = await supabase
     .from('travel_dates')
     .select('travel_slug, booked_seat, is_custom_travel, departure_date, return_date')
+    .eq('deleted', false)
 
   if (error) {
     throw createError({

--- a/server/api/v1/stripe/index.post.js
+++ b/server/api/v1/stripe/index.post.js
@@ -7,15 +7,22 @@ export default defineEventHandler(async (event) => {
     .from('booked_dates')
     .select('deal_id')
     .eq('id', bookedId)
+    .eq('deleted', false)
     .single()
 
   if (error) {
+    // On refuse d'ouvrir une NOUVELLE session de paiement sur une réservation
+    // supprimée. À ne pas confondre avec le webhook entrant (server/utils/stripe.js),
+    // qui lui ressuscite la ligne : un paiement déjà encaissé fait foi.
+    const deleted = await booking.isBookedDateDeleted(bookedId)
     throw funnelReporter.funnelCreateError({
-      statusCode: 400,
-      code: 'STRIPE_BOOKED_DATE_NOT_FOUND',
+      statusCode: deleted ? 410 : 400,
+      code: deleted ? 'STRIPE_BOOKED_DATE_DELETED' : 'STRIPE_BOOKED_DATE_NOT_FOUND',
       step: 'payment',
       origin: { field: 'bookedId', received: bookedId, endpoint: 'booked_dates' },
-      message: 'Impossible de récupérer le deal depuis booked_dates',
+      message: deleted
+        ? 'Cette réservation a été supprimée, le lien de paiement n\'est plus valide'
+        : 'Impossible de récupérer le deal depuis booked_dates',
     })
   }
   const deal_id = data.deal_id

--- a/server/api/v1/webhooks/booking/cronjob.js
+++ b/server/api/v1/webhooks/booking/cronjob.js
@@ -14,6 +14,7 @@ export default defineEventHandler(async (event) => {
   const { data, error } = await supabase
     .from('booked_dates')
     .select('*')
+    .eq('deleted', false)
     .eq('is_option', true)
     .lt('expiracy_date', today.toISOString())
 

--- a/server/api/v1/webhooks/booking/departure-stages.js
+++ b/server/api/v1/webhooks/booking/departure-stages.js
@@ -20,6 +20,7 @@ export default defineEventHandler(async (event) => {
   const { data: rows, error: fetchError } = await supabase
     .from('travel_dates')
     .select('id, departure_date, return_date, booked_seat, min_travelers, departure_id')
+    .eq('deleted', false)
     .not('departure_id', 'is', null)
 
   if (fetchError) {

--- a/server/api/v1/webhooks/booking/status_change.js
+++ b/server/api/v1/webhooks/booking/status_change.js
@@ -46,6 +46,7 @@ export default defineEventHandler(async (event) => {
     const { data: rows, error: fetchError } = await supabase
       .from('travel_dates')
       .select('id, booked_seat, min_travelers, max_travelers, status')
+      .eq('deleted', false)
       .range(from, from + PAGE_SIZE - 1)
 
     if (fetchError) {

--- a/server/utils/alma.js
+++ b/server/utils/alma.js
@@ -173,33 +173,49 @@ const handlePaymentSession = async (session) => {
   console.log('contact', contact)
 
   // BOOKING MANAGEMENT SUPABASE
-  const { data: bookedDate, error } = await supabase
-    .from('booked_dates')
-    .update({
-      is_option: false,
-      expiracy_date: null,
-      booked_places: order.nbTravelers,
-      transaction_id: session.id,
-      payment_type: 'alma',
-    })
-    .eq('deal_id', order.id)
-    .select('*')
-    .single()
+  // Même politique que stripe.js : le paiement ressuscite une réservation
+  // soft-deleted et alerte Slack.
+  const res = await booking.upsertBookedDateForDeal(order.id, null, {
+    is_option: false,
+    expiracy_date: null,
+    booked_places: order.nbTravelers,
+    transaction_id: session.id,
+    payment_type: 'alma',
+  }, { user: { email: 'alma-webhook' }, allowMove: false, resetOnRevive: false })
 
-  if (error) {
-    console.error('Error updating booked_dates', error)
+  const bookedDate = res.row
+  if (!bookedDate) {
+    console.error('Error updating booked_dates', res.error)
+    await slack.alertOrphanPayment({
+      dealId: order.id,
+      provider: 'alma',
+      paymentType: 'alma',
+      transactionId: session.id,
+    })
   }
   else {
-    const { data: allBooked, error: sumAllBookedError } = await supabase
-      .from('booked_dates')
-      .select('booked_places')
-      .eq('travel_date_id', bookedDate.travel_date_id)
-    if (sumAllBookedError) return { error: sumAllBookedError.message }
+    if (res.revived) {
+      await slack.alertPaymentOnDeletedBooking({
+        dealId: order.id,
+        bookedId: bookedDate.id,
+        travelDateId: bookedDate.travel_date_id,
+        travelSlug: deal.slug,
+        deletedAt: res.previous?.deleted_at,
+        deletedBy: res.previous?.deleted_by,
+        deletedReason: res.previous?.deleted_reason,
+        paymentType: 'alma',
+        provider: 'alma',
+      })
+      await logDateActivity(bookedDate.travel_date_id, { email: 'alma-webhook' }, 'deal_restored', {
+        deal_id: order.id,
+        booked_id: bookedDate.id,
+        cause: 'late_payment',
+        previous_reason: res.previous?.deleted_reason || null,
+      })
+    }
 
-    const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
-    console.log('totalBooked', totalBooked)
     // Update the travel_dates.booked_seat + derived status
-    const recompute = await booking.updateTravelDate(bookedDate.travel_date_id, totalBooked)
+    const recompute = await booking.recomputeBookedSeatAndStatus(bookedDate.travel_date_id)
     if (recompute?.error) return { error: recompute.error }
 
     // Departure record deal management (pipeline 4 "Gestions Départs")

--- a/server/utils/booking.js
+++ b/server/utils/booking.js
@@ -11,7 +11,7 @@ const computeTravelDateStatus = ({ booked_seat, min_travelers, max_travelers }) 
 }
 
 const retrieveBooking = async (slug) => {
-  const query = supabase.from('travel_dates').select()
+  const query = supabase.from('travel_dates').select().eq('deleted', false)
   try {
     if (slug) {
       const { error, data } = await query.eq('travel_slug', slug).single()
@@ -33,46 +33,98 @@ const retrieveBooking = async (slug) => {
   }
 }
 
-const retrieveBookedDates = async (travel_date_id) => {
-  const { error, data } = await supabase
+/**
+ * Garde partagée des endpoints BMS : la date existe, appartient bien à ce slug,
+ * et n'est pas supprimée. Remplace la requête dupliquée dans ~17 handlers.
+ *
+ * Les endpoints qui ÉCRIVENT passent includeDeleted: false (refuser d'écrire dans
+ * un tombstone). Ceux en lecture seule atteignables depuis l'écran de restauration
+ * passent includeDeleted: true et rendent en lecture seule via `deleted`.
+ */
+const requireActiveTravelDate = async (dateId, slug, { includeDeleted = false } = {}) => {
+  let query = supabase
+    .from('travel_dates')
+    .select('*')
+    .eq('id', dateId)
+    .eq('travel_slug', slug)
+  if (!includeDeleted) query = query.eq('deleted', false)
+  const { data, error } = await query.maybeSingle()
+  if (error || !data) {
+    throw createError({ statusCode: 404, statusMessage: 'Date introuvable' })
+  }
+  return data
+}
+
+const retrieveBookedDates = async (travel_date_id, { includeDeleted = false } = {}) => {
+  let query = supabase
     .from('booked_dates')
     .select()
     .eq('travel_date_id', travel_date_id)
+  if (!includeDeleted) query = query.eq('deleted', false)
+  const { error, data } = await query
   if (error) console.error('Supabase retrieve error:', error)
   return data
 }
 
-const retrieveBookedDateById = async (bookedId) => {
-  const { data: bookedRow, error: fetchError } = await supabase
-    .from('booked_dates')
-    .select('travel_date_id, deal_id')
-    .eq('id', bookedId)
-    .single()
-  if (fetchError) {
-    console.error('Supabase retrieve error:', fetchError)
-    return { error: fetchError.message }
-  }
-  return bookedRow
-}
+// Contrat : `null | row`.
+//
+// Ces deux helpers renvoyaient `{ error: '...' }` en cas d'échec. Comme
+// `.single()` remonte une erreur PGRST116 sur zéro ligne, « pas trouvé »
+// devenait un objet TRUTHY — d'où le `if (bookedRow)` de dealDelete.post.js
+// qui passait systématiquement. `.maybeSingle()` + null règle les deux.
+const BOOKED_DATE_COLUMNS
+  = 'id, travel_date_id, deal_id, booked_places, is_option, expiracy_date, '
+    + 'transaction_id, payment_type, deleted, deleted_at, deleted_by, deleted_reason'
 
-const retrieveBookedDateByDealId = async (dealId) => {
-  const { error, data } = await supabase
+const retrieveBookedDateById = async (bookedId, { includeDeleted = false } = {}) => {
+  let query = supabase
     .from('booked_dates')
-    .select('travel_date_id')
-    .eq('deal_id', dealId)
-    .single()
+    .select(BOOKED_DATE_COLUMNS)
+    .eq('id', bookedId)
+  if (!includeDeleted) query = query.eq('deleted', false)
+  const { data, error } = await query.maybeSingle()
   if (error) {
     console.error('Supabase retrieve error:', error)
-    return { error: error.message }
+    return null
   }
   return data
 }
 
+const retrieveBookedDateByDealId = async (dealId, { includeDeleted = false } = {}) => {
+  let query = supabase
+    .from('booked_dates')
+    .select(BOOKED_DATE_COLUMNS)
+    .eq('deal_id', dealId)
+  if (!includeDeleted) query = query.eq('deleted', false)
+  const { data, error } = await query.maybeSingle()
+  if (error) {
+    console.error('Supabase retrieve error:', error)
+    return null
+  }
+  return data
+}
+
+// Distingue « supprimée » de « n'a jamais existé » sur le chemin d'erreur des
+// endpoints de paiement, pour que l'ops ne cherche pas un booked_id fantôme.
+const isBookedDateDeleted = async (bookedId) => {
+  if (!bookedId) return false
+  const { data } = await supabase
+    .from('booked_dates')
+    .select('deleted')
+    .eq('id', bookedId)
+    .maybeSingle()
+  return data?.deleted === true
+}
+
+// Le chemin argent : booked_seat en découle directement. Pas d'option
+// includeDeleted ici volontairement — compter une réservation supprimée gonfle
+// booked_seat, bascule la date en 'guaranteed' et arrête la vente publique.
 const retrieveBookedPlacesByTravelDateId = async (travel_date_id) => {
   const { error: sumError, data: allBooked } = await supabase
     .from('booked_dates')
     .select('booked_places')
     .eq('travel_date_id', travel_date_id)
+    .eq('deleted', false)
   if (sumError) {
     console.error('Supabase sum error:', sumError)
     return { error: sumError.message }
@@ -139,39 +191,191 @@ const recomputeStatusOnly = async (travel_date_id) => {
   return { id: travel_date_id, status: nextStatus, updated: true }
 }
 
-const deleteBookedDateByDealId = async (dealId) => {
-  const { error } = await supabase
-    .from('booked_dates')
-    .delete()
-    .eq('deal_id', dealId)
-  if (error) {
-    console.error('Supabase delete error:', error)
-    return { error: error.message }
-  }
-  return dealId
+// Recalcule plusieurs dates d'un coup. Indispensable après une résurrection qui
+// DÉPLACE une réservation : la date d'origine et la date cible doivent toutes
+// les deux voir leur booked_seat recalculé.
+const recomputeManyBookedSeatAndStatus = (travelDateIds = []) => {
+  const ids = [...new Set(travelDateIds.filter(Boolean))]
+  return Promise.all(ids.map(id => recomputeBookedSeatAndStatus(id)))
 }
 
-const deleteBookedDateById = async (bookedId) => {
-  const { error } = await supabase
-    .from('booked_dates')
-    .delete()
-    .eq('id', bookedId)
-  if (error) {
-    console.error('Supabase delete error:', error)
-    return { error: error.message }
+// =========================================================================
+// Suppression / restauration
+// =========================================================================
+// `deleteBookedDateByDealId` et `deleteBookedDateById` (DELETE physiques) ont
+// été SUPPRIMÉES et non renommées : tout appelant oublié échoue bruyamment au
+// lieu de continuer à supprimer en dur en silence.
+
+const softDeleteBookedDateByDealId = (dealId, { user = null, reason, batch = null } = {}) =>
+  softDelete.remove('booked_dates', q => q.eq('deal_id', dealId), {
+    user, reason, batch, select: 'id, travel_date_id, deal_id, booked_places',
+  })
+
+const softDeleteBookedDateById = (bookedId, { user = null, reason, batch = null } = {}) =>
+  softDelete.remove('booked_dates', q => q.eq('id', bookedId), {
+    user, reason, batch, select: 'id, travel_date_id, deal_id, booked_places',
+  })
+
+const restoreBookedDateById = bookedId =>
+  softDelete.restore('booked_dates', q => q.eq('id', bookedId), {
+    select: 'id, travel_date_id, deal_id, booked_places',
+  })
+
+// Colonnes remises à zéro quand on ressuscite une ligne pour une NOUVELLE
+// assignation (le patch de l'appelant est appliqué par-dessus).
+const REVIVE_RESET = {
+  booked_places: 0,
+  is_option: false,
+  expiracy_date: null,
+  transaction_id: null,
+  payment_type: null,
+}
+
+/**
+ * Point d'entrée unique de « mettre ce deal sur cette date ».
+ *
+ * `booked_dates` porte une contrainte UNIQUE(deal_id) : un deal = UNE ligne
+ * physique à vie. Toute écriture est donc en réalité un upsert-avec-résurrection,
+ * jamais un second INSERT. C'est ce qui garde le `booked_id` stable, et donc les
+ * liens de paiement (`/checkout?booked_id=...`) déjà poussés dans AC valides
+ * après une suppression puis une ré-assignation.
+ *
+ * @param {number|string} dealId
+ * @param {string|null}   travelDateId  date cible ; null = « là où elle est déjà »
+ *                                      (les webhooks de paiement passent null)
+ * @param {object}        patch         colonnes à écrire
+ * @param {object}        opts
+ * @param {object}  [opts.user]           piste d'audit ({ email: 'stripe-webhook' }…)
+ * @param {boolean} [opts.allowMove]      true  → un tombstone posé sur une autre date
+ *                                                peut être repointé sur travelDateId
+ *                                        false → on conserve son travel_date_id
+ * @param {boolean} [opts.resetOnRevive]  true  → REVIVE_RESET avant d'appliquer patch
+ * @param {boolean} [opts.force]          true  → accepte de déplacer une ligne ACTIVE
+ *                                                posée sur une autre date (sinon conflit)
+ *
+ * @returns {Promise<{
+ *   row: object|null,       ligne booked_dates résultante
+ *   previous: object|null,  la ligne AVANT écriture (porte l'ancien travel_date_id
+ *                           et l'info de tombstone) — toujours renvoyée
+ *   created: boolean,
+ *   revived: boolean,
+ *   moved: boolean,         travel_date_id a changé
+ *   conflict: 'other_date'|null,
+ *   error: string|null,
+ * }>}
+ */
+const upsertBookedDateForDeal = async (dealId, travelDateId, patch = {}, opts = {}) => {
+  const { user = null, allowMove = false, resetOnRevive = false, force = false } = opts
+  const empty = { row: null, previous: null, created: false, revived: false, moved: false, conflict: null, error: null }
+  // travelDateId non fourni = « là où la ligne est déjà » (webhooks de paiement).
+  const noTarget = travelDateId === null || travelDateId === undefined
+
+  const readExisting = async () => {
+    const { data, error } = await supabase
+      .from('booked_dates')
+      .select('*')
+      .eq('deal_id', dealId)
+      .maybeSingle()
+    if (error) return { error: error.message }
+    return { data }
   }
-  return bookedId
+
+  let existing = await readExisting()
+  if (existing.error) return { ...empty, error: existing.error }
+
+  // --- Aucune ligne : INSERT ---------------------------------------------
+  if (!existing.data) {
+    const { data, error } = await supabase
+      .from('booked_dates')
+      .insert([{ travel_date_id: travelDateId, deal_id: dealId, deleted: false, ...patch }])
+      .select('*')
+      .maybeSingle()
+
+    if (!error) return { ...empty, row: data, created: true }
+
+    // 23505 = unique_violation. On teste le CODE et pas le message : le texte
+    // dépend de la version de Postgres et de lc_messages. Cas réel : les 3
+    // tentatives du funnel (useStepperDeal.js, 700 ms d'écart) qui lisent
+    // toutes « pas de ligne » puis insèrent en concurrence.
+    if (error.code !== '23505') {
+      console.error('[upsertBookedDateForDeal] insert failed', error)
+      return { ...empty, error: error.message }
+    }
+    existing = await readExisting()
+    if (existing.error) return { ...empty, error: existing.error }
+    if (!existing.data) return { ...empty, error: 'Conflit d\'unicité sans ligne correspondante' }
+  }
+
+  const previous = existing.data
+
+  // --- Ligne active ------------------------------------------------------
+  if (!previous.deleted) {
+    const sameDate = noTarget || previous.travel_date_id === travelDateId
+    if (!sameDate && !force) {
+      // Aucune écriture : l'appelant décide (409 côté assign-deal).
+      return { ...empty, row: previous, previous, conflict: 'other_date' }
+    }
+
+    const update = { ...patch }
+    if (!sameDate) update.travel_date_id = travelDateId
+
+    const { data, error } = await supabase
+      .from('booked_dates')
+      .update(update)
+      .eq('deal_id', dealId)
+      .select('*')
+      .maybeSingle()
+    if (error) return { ...empty, previous, error: error.message }
+
+    // created/revived à false : c'est le chemin IDEMPOTENT sur lequel
+    // atterrissent les retries du funnel, qui recevaient un 409 auparavant.
+    return { ...empty, row: data, previous, moved: !sameDate }
+  }
+
+  // --- Tombstone : résurrection ------------------------------------------
+  const target = allowMove && !noTarget ? travelDateId : previous.travel_date_id
+  const update = {
+    ...softDelete.clear(),
+    travel_date_id: target,
+    ...(resetOnRevive ? REVIVE_RESET : {}),
+    ...patch,
+  }
+
+  const { data, error } = await supabase
+    .from('booked_dates')
+    .update(update)
+    .eq('deal_id', dealId)
+    .select('*')
+    .maybeSingle()
+  if (error) return { ...empty, previous, error: error.message }
+
+  console.log(`[upsertBookedDateForDeal] REVIVE dealId=${dealId} bookedId=${data?.id} `
+    + `from=${previous.travel_date_id} to=${target} reason=${previous.deleted_reason} `
+    + `by=${user?.email || 'system'}`)
+
+  return {
+    ...empty,
+    row: data,
+    previous,
+    revived: true,
+    moved: target !== previous.travel_date_id,
+  }
 }
 
 export default {
   retrieveBooking,
+  requireActiveTravelDate,
   retrieveBookedDates,
   retrieveBookedDateByDealId,
   retrieveBookedDateById,
+  isBookedDateDeleted,
   retrieveBookedPlacesByTravelDateId,
   updateTravelDate,
   recomputeBookedSeatAndStatus,
+  recomputeManyBookedSeatAndStatus,
   recomputeStatusOnly,
-  deleteBookedDateByDealId,
-  deleteBookedDateById,
+  softDeleteBookedDateByDealId,
+  softDeleteBookedDateById,
+  restoreBookedDateById,
+  upsertBookedDateForDeal,
 }

--- a/server/utils/departures.js
+++ b/server/utils/departures.js
@@ -52,6 +52,7 @@ const computeDepartureEnrichment = async (travelDateId, travelDate) => {
     .from('booked_dates')
     .select('deal_id, booked_places')
     .eq('travel_date_id', travelDateId)
+    .eq('deleted', false)
     .gt('booked_places', 0)
 
   let totalValue = 0
@@ -239,10 +240,16 @@ const cleanupDepartureDealIfEmpty = async (travelDateId) => {
 
     if (fetchError || !travelDate || !travelDate.departure_id) return
 
+    // ⚠️ Le .eq('deleted', false) est indispensable : cette sonde supposait que la
+    // ligne était PHYSIQUEMENT absente. Une réservation soft-deleted garde
+    // booked_places > 0 (la restauration doit être exacte), donc sans ce filtre la
+    // sonde conclut « il reste des clients payants » et le deal de départ
+    // pipeline 4 n'est plus jamais nettoyé.
     const { data: remainingPaid } = await supabase
       .from('booked_dates')
       .select('id')
       .eq('travel_date_id', travelDateId)
+      .eq('deleted', false)
       .gt('booked_places', 0)
       .limit(1)
 

--- a/server/utils/margins.js
+++ b/server/utils/margins.js
@@ -239,6 +239,7 @@ const getMarginForVoyage = async (voyageSlug, year = null) => {
     .from('voyage_margins')
     .select('pax, margin_per_traveler, year, season_id, updated_at, updated_by')
     .eq('voyage_slug', voyageSlug)
+    .eq('deleted', false)
     .order('year', { ascending: false })
     .order('pax', { ascending: true })
 
@@ -265,6 +266,11 @@ const upsertMarginForVoyage = async (voyageSlug, rows, editorEmail, year, season
       margin_per_traveler: r.margin_per_traveler !== null && r.margin_per_traveler !== '' ? Number(r.margin_per_traveler) : null,
       updated_at: new Date().toISOString(),
       updated_by: editorEmail || null,
+      // Sans ça, ON CONFLICT DO UPDATE écrirait droit dans une ligne supprimée
+      // sans lever le drapeau : l'opérateur saisit une marge, voit
+      // « enregistré », et la valeur reste invisible pour toujours tout en
+      // faussant silencieusement tous les calculs de marge du voyage.
+      ...softDelete.clear(),
     }))
 
   if (!payload.length) return []
@@ -353,6 +359,7 @@ const getTotalInvoicesForDate = async (travelDateId) => {
     .from('date_invoices')
     .select('amount')
     .eq('travel_date_id', travelDateId)
+    .eq('deleted', false)
 
   if (error) throw error
   return (data || []).reduce((acc, r) => acc + Number(r.amount || 0), 0)
@@ -429,6 +436,7 @@ const resolveBaseMarginPerPax = async (travelDate, realPax) => {
       .from('voyage_margins')
       .select('margin_per_traveler, year, season_id')
       .eq('voyage_slug', travelDate.travel_slug)
+      .eq('deleted', false)
       .eq('pax', realPax)
       .not('margin_per_traveler', 'is', null),
   ])

--- a/server/utils/slack.js
+++ b/server/utils/slack.js
@@ -1,0 +1,85 @@
+import axios from 'axios'
+
+// Alertes Slack partagées.
+//
+// Il n'existait pas de helper général : huit blocs axios/$fetch ad hoc étaient
+// dispersés dans stripe.js, alma.js, activecampaign.js, cronjob.js et les
+// webhooks. Les deux « helpers » existants (activecampaign.optionNotification,
+// funnelReporter.slackTransport) sont chacun liés à un webhook et à une forme de
+// payload précise.
+//
+// Règles :
+//   - no-op silencieux quand la variable d'env n'est pas définie (comme
+//     funnelReporter), donc la fonctionnalité est inerte tant que le webhook
+//     n'est pas configuré ;
+//   - ne throw JAMAIS. Une panne Slack ne doit pas faire échouer un webhook de
+//     paiement — c'est déjà le comportement de alma.js:28, on en fait la règle.
+
+const isDev = process.env.NODE_ENV !== 'production'
+
+const send = async (webhookUrl, text) => {
+  if (!webhookUrl) return false
+  if (isDev) {
+    console.log('[slack:dev]', text)
+    return false
+  }
+  try {
+    await axios({
+      url: webhookUrl,
+      method: 'post',
+      data: { blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] },
+    })
+    return true
+  }
+  catch (err) {
+    console.error('[slack] send failed:', err.message)
+    return false
+  }
+}
+
+const siteUrl = () => (process.env.NUXT_PUBLIC_SITE_URL || 'https://odysway.com').replace(/\/$/, '')
+
+/**
+ * Un paiement est arrivé sur une réservation soft-deleted : on l'a ressuscitée.
+ * Le paiement fait foi, mais l'équipe doit savoir que la réservation est
+ * revenue — typiquement un deal marqué « Perdu » dont le client paie quand même.
+ */
+const alertPaymentOnDeletedBooking = ({
+  dealId, bookedId, travelDateId, travelSlug,
+  deletedAt, deletedBy, deletedReason, paymentType, provider,
+}) => {
+  const bms = travelSlug && travelDateId
+    ? `\n<${siteUrl()}/booking-management/${travelSlug}/${travelDateId}|Ouvrir dans le BMS>`
+    : ''
+  return send(process.env.SLACK_URL_PAIEMENTS,
+    `:warning: *Paiement sur une réservation supprimée — réservation réactivée*\n`
+    + `• Deal : \`${dealId}\`  ·  booked_id : \`${bookedId}\`\n`
+    + `• Paiement : ${provider} / ${paymentType}\n`
+    + `• Avait été supprimée le ${deletedAt || '?'} par ${deletedBy || '?'} (raison : ${deletedReason || '?'})\n`
+    + `La réservation a été remise en actif et les places recomptées.${bms}`)
+}
+
+/**
+ * Un paiement a abouti sans qu'aucune ligne booked_dates ne corresponde au deal.
+ * Trou préexistant : stripe.js et alma.js se contentaient d'un console.error, si
+ * bien qu'un paiement pouvait être encaissé sans trace Supabase ni alerte.
+ */
+const alertOrphanPayment = ({ dealId, provider, paymentType, transactionId }) =>
+  send(process.env.SLACK_URL_FUNNEL_ERRORS,
+    `:rotating_light: *Paiement orphelin — aucune réservation en base*\n`
+    + `• Deal : \`${dealId}\`\n`
+    + `• Paiement : ${provider} / ${paymentType}  ·  transaction : \`${transactionId || '?'}\`\n`
+    + `Aucune ligne booked_dates pour ce deal : l'argent est encaissé, la réservation est à recréer à la main.`)
+
+/**
+ * Une réservation active a été trouvée sous une date supprimée : la cascade de
+ * suppression l'a manquée (échec en cours de route, cascade non transactionnelle).
+ */
+const alertCascadeLeak = ({ dealId, bookedId, travelDateId }) =>
+  send(process.env.SLACK_URL_FUNNEL_ERRORS,
+    `:broken_heart: *Fuite de cascade — réservation active sous une date supprimée*\n`
+    + `• Deal : \`${dealId}\`  ·  booked_id : \`${bookedId}\`\n`
+    + `• Date supprimée : \`${travelDateId}\`\n`
+    + `La réservation a été déplacée vers la nouvelle date. Vérifier la cohérence de la date supprimée.`)
+
+export default { send, alertPaymentOnDeletedBooking, alertOrphanPayment, alertCascadeLeak }

--- a/server/utils/softDelete.js
+++ b/server/utils/softDelete.js
@@ -1,0 +1,123 @@
+import supabase from './supabase'
+
+// Soft delete standard. Voir supabase/migrations/20260801090000_soft_delete.sql.
+//
+// Toute suppression du projet passe par ici : la contrainte
+// `<table>_tombstone_chk` en base refuse un `deleted = true` sans deleted_at ni
+// deleted_reason, donc un `.update({ deleted: true })` écrit à la main échoue.
+//
+// Export par défaut objet (comme booking., departures., margins.) : les noms
+// `remove` / `restore` sont trop génériques pour l'auto-import de nitro
+// (nuxt.config.ts -> nitro.imports.dirs: ['server/utils/**']).
+
+export const DELETE_REASONS = {
+  // Action opérateur depuis le BMS.
+  MANUAL: 'manual',
+  // Enfant supprimé PARCE QUE sa date parente l'a été. C'est cette valeur qui
+  // rend la restauration correcte : restaurer une date ne restaure que ses
+  // enfants en cascade, jamais ceux supprimés un par un avant.
+  CASCADE_TRAVEL_DATE: 'cascade_travel_date',
+  AC_DEAL_DELETED: 'ac_deal_deleted',
+  AC_DEAL_TRASHED: 'ac_deal_trashed',
+  AC_DEAL_LOST: 'ac_deal_lost',
+  AC_CONTACT_DELETED: 'ac_contact_deleted',
+  PURGE: 'purge',
+}
+
+// Le payload « pierre tombale ». Exporté pour les appelants qui doivent l'écrire
+// à l'intérieur d'un .update() plus large (cascade, résurrection) plutôt que de
+// faire une seconde écriture.
+const stamp = (user, reason, batch = null) => ({
+  deleted: true,
+  deleted_at: new Date().toISOString(),
+  deleted_by: user?.email || 'system',
+  deleted_reason: reason,
+  deleted_batch: batch,
+})
+
+const clear = () => ({
+  deleted: false,
+  deleted_at: null,
+  deleted_by: null,
+  deleted_reason: null,
+  deleted_batch: null,
+})
+
+const newBatch = () => globalThis.crypto.randomUUID()
+
+/**
+ * Supprime (soft) les lignes correspondant au filtre.
+ *
+ * @param {string} table
+ * @param {(query) => query} applyFilters  ex. q => q.eq('travel_date_id', id)
+ * @param {object}   opts
+ * @param {object}   [opts.user]    { email } pour la piste d'audit
+ * @param {string}   [opts.reason]  DELETE_REASONS.*
+ * @param {string}   [opts.batch]   id de lot, pour regrouper une cascade
+ * @param {string}   [opts.select]  colonnes renvoyées
+ * @returns {Promise<{ rows: object[], count: number, error: string|null }>}
+ *
+ * Le garde `.eq('deleted', false)` rend l'opération idempotente : rejouer une
+ * cascade n'écrase jamais la raison d'un tombstone existant. C'est exactement
+ * cette propriété qui rend la restauration par raison correcte — une
+ * réservation supprimée manuellement AVANT la suppression de sa date garde
+ * `manual` et ne remonte donc pas avec la date.
+ */
+const remove = async (table, applyFilters, {
+  user = null,
+  reason = DELETE_REASONS.MANUAL,
+  batch = null,
+  select = 'id',
+} = {}) => {
+  const query = supabase
+    .from(table)
+    .update(stamp(user, reason, batch))
+    .eq('deleted', false)
+
+  const { data, error } = await applyFilters(query).select(select)
+  if (error) {
+    console.error(`[softDelete] ${table} remove failed`, error)
+    return { rows: [], count: 0, error: error.message }
+  }
+  return { rows: data || [], count: data?.length || 0, error: null }
+}
+
+/**
+ * Miroir de remove(). Garde sur `.eq('deleted', true)` : restaurer deux fois
+ * est un no-op, et on ne réinitialise jamais l'audit d'une ligne active.
+ */
+const restore = async (table, applyFilters, { select = 'id' } = {}) => {
+  const query = supabase
+    .from(table)
+    .update(clear())
+    .eq('deleted', true)
+
+  const { data, error } = await applyFilters(query).select(select)
+  if (error) {
+    console.error(`[softDelete] ${table} restore failed`, error)
+    return { rows: [], count: 0, error: error.message }
+  }
+  return { rows: data || [], count: data?.length || 0, error: null }
+}
+
+/**
+ * Select « lignes actives » ergonomique. Renvoie un filter builder PostgREST
+ * normal, donc le chaînage habituel continue.
+ *
+ * À n'utiliser QUE dans les helpers chauds (booking.js, departures.js,
+ * margins.js) : ailleurs, écrire le `.eq('deleted', false)` littéral, sinon
+ * `grep "from('booked_dates')"` cesse d'être un inventaire complet — et c'est
+ * comme ça que l'audit de cette migration a été construit.
+ */
+const active = (table, columns = '*') =>
+  supabase.from(table).select(columns).eq('deleted', false)
+
+export default {
+  remove,
+  restore,
+  active,
+  stamp,
+  clear,
+  newBatch,
+  REASONS: DELETE_REASONS,
+}

--- a/server/utils/stripe.js
+++ b/server/utils/stripe.js
@@ -417,33 +417,57 @@ const handlePaymentSession = async (session, paymentType) => {
   }
 
   // BOOKING MANAGEMENT SUPABASE
-  const { data: bookedDate, error } = await supabase
-    .from('booked_dates')
-    .update({
-      is_option: false,
-      expiracy_date: null,
-      booked_places: deal.nbTravelers,
-      transaction_id: session.payment_intent || session.id,
-      payment_type: paymentType,
+  //
+  // Le paiement fait foi : si la réservation a été soft-deleted entre-temps
+  // (deal marqué « Perdu », date supprimée…), on la RESSUSCITE et on alerte.
+  // allowMove: false — le paiement ne déplace pas la réservation, il la
+  // réactive là où elle était. resetOnRevive: false — on ne perd pas
+  // l'historique de la ligne, le patch ci-dessous suffit.
+  const res = await booking.upsertBookedDateForDeal(order.dealId, null, {
+    is_option: false,
+    expiracy_date: null,
+    booked_places: deal.nbTravelers,
+    transaction_id: session.payment_intent || session.id,
+    payment_type: paymentType,
+  }, { user: { email: 'stripe-webhook' }, allowMove: false, resetOnRevive: false })
+
+  const bookedDate = res.row
+  if (!bookedDate) {
+    // Auparavant un simple console.error : un paiement pouvait aboutir sans
+    // aucune trace Supabase et sans que personne ne soit prévenu.
+    console.error('Error updating booked_dates', res.error)
+    await slack.alertOrphanPayment({
+      dealId: order.dealId,
+      provider: 'stripe',
+      paymentType,
+      transactionId: session.payment_intent || session.id,
     })
-    .eq('deal_id', order.dealId)
-    .select('*')
-    .single()
-  if (error) {
-    console.error('Error updating booked_dates', error)
   }
   else {
     console.log('booked_dates updated', bookedDate)
 
-    const { data: allBooked, error: sumAllBookedError } = await supabase
-      .from('booked_dates')
-      .select('booked_places')
-      .eq('travel_date_id', bookedDate.travel_date_id)
-    if (sumAllBookedError) return { error: sumAllBookedError.message }
+    if (res.revived) {
+      await slack.alertPaymentOnDeletedBooking({
+        dealId: order.dealId,
+        bookedId: bookedDate.id,
+        travelDateId: bookedDate.travel_date_id,
+        travelSlug: deal.slug,
+        deletedAt: res.previous?.deleted_at,
+        deletedBy: res.previous?.deleted_by,
+        deletedReason: res.previous?.deleted_reason,
+        paymentType,
+        provider: 'stripe',
+      })
+      await logDateActivity(bookedDate.travel_date_id, { email: 'stripe-webhook' }, 'deal_restored', {
+        deal_id: order.dealId,
+        booked_id: bookedDate.id,
+        cause: 'late_payment',
+        previous_reason: res.previous?.deleted_reason || null,
+      })
+    }
 
-    const totalBooked = (allBooked || []).reduce((acc, row) => acc + (row.booked_places || 0), 0)
     // Update the travel_dates.booked_seat + derived status
-    const recompute = await booking.updateTravelDate(bookedDate.travel_date_id, totalBooked)
+    const recompute = await booking.recomputeBookedSeatAndStatus(bookedDate.travel_date_id)
     if (recompute?.error) return { error: recompute.error }
 
     // Departure record deal management (pipeline 4 "Gestions Départs")

--- a/supabase/dashboard/01_target_tables.sql
+++ b/supabase/dashboard/01_target_tables.sql
@@ -164,3 +164,39 @@ ALTER TABLE "public"."activecampaign_deals"   REPLICA IDENTITY FULL;
 ALTER TABLE "public"."activecampaign_clients" REPLICA IDENTITY FULL;
 ALTER TABLE "public"."travel_dates"           REPLICA IDENTITY FULL;
 ALTER TABLE "public"."booked_dates"           REPLICA IDENTITY FULL;
+
+-- ============================================================================
+-- Soft delete — colonnes miroir (cf. supabase/migrations/20260801090000_soft_delete.sql)
+-- ============================================================================
+-- ⚠️ CE BLOC DOIT ÊTRE JOUÉ SUR LE PROJET DASHBOARD **AVANT** LA MIGRATION PROD.
+--
+-- mirror-sync (supabase/functions/mirror-sync/index.ts) fait `upsert(record)` avec
+-- la ligne prod BRUTE. Dès que prod gagne une colonne que le miroir n'a pas,
+-- PostgREST répond PGRST204 et TOUT changement sur les 4 tables mirrorées cesse
+-- d'arriver — silencieusement, avec seulement un 500 dans les logs de l'edge function.
+--
+-- Pas de CHECK ici volontairement : le miroir doit accepter tel quel ce que prod
+-- envoie, y compris un état transitoire. Les invariants sont tenus côté prod.
+--
+-- Vérifier aussi dans Supabase prod (Database > Webhooks) que chaque trigger
+-- mirror_sync_* se déclenche sur UPDATE et pas seulement INSERT/DELETE :
+-- un soft delete est un UPDATE. Sinon les suppressions n'atteignent jamais le
+-- miroir et les vues continuent de compter des réservations supprimées.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'activecampaign_clients', 'activecampaign_deals', 'travel_dates', 'booked_dates'
+  ] LOOP
+    EXECUTE format('ALTER TABLE public.%I
+        ADD COLUMN IF NOT EXISTS deleted        boolean DEFAULT false,
+        ADD COLUMN IF NOT EXISTS deleted_at     timestamptz,
+        ADD COLUMN IF NOT EXISTS deleted_by     text,
+        ADD COLUMN IF NOT EXISTS deleted_reason text,
+        ADD COLUMN IF NOT EXISTS deleted_batch  uuid', t);
+    EXECUTE format('UPDATE public.%I SET deleted = false WHERE deleted IS NULL', t);
+  END LOOP;
+END $$;
+
+-- Les vues de 03_views.sql filtrent déjà `deleted = false AND is_test = false` :
+-- côté analytique, rien d'autre à faire une fois ces colonnes en place.

--- a/supabase/migrations/20260801090000_soft_delete.sql
+++ b/supabase/migrations/20260801090000_soft_delete.sql
@@ -1,0 +1,221 @@
+-- Soft delete standard sur les tables Supabase.
+-- Voir le plan /Users/alex/.claude/plans/j-aimerais-que-tu-planifies-enumerated-lake.md
+--
+-- Jusqu'ici toutes les suppressions du projet étaient des DELETE physiques. Les colonnes
+-- `deleted` existaient déjà sur travel_dates et booked_dates mais rien ne les écrivait
+-- jamais — seules 4 lectures les filtraient, de façon incohérente.
+--
+-- Cette migration est PUREMENT ADDITIVE : aucune ligne existante ne change de sens
+-- (tout le monde reste `deleted = false`), et aucun code ne lit encore les nouvelles
+-- colonnes. Elle doit précéder la passe de filtrage des lectures, car avant le
+-- backfill NOT NULL, `.eq('deleted', false)` écarte les NULL alors que
+-- `.not('deleted','is',true)` les garde.
+--
+-- ⚠️ AVANT DE JOUER CECI EN PROD : appliquer les mêmes ajouts de colonnes au projet
+-- dashboard (supabase/dashboard/01_target_tables.sql). mirror-sync upsert la ligne prod
+-- BRUTE ; une colonne inconnue côté miroir fait échouer l'upsert en PGRST204 et toute la
+-- synchro analytique s'arrête silencieusement.
+
+-- =========================================================================
+-- 0. Mesure de l'existant — à lire dans la sortie avant/après
+-- =========================================================================
+-- Les pièges NULL préexistants sur booked_dates : travelers-count.get.js filtre
+-- `.eq('is_test', false).eq('is_option', false)`, donc toute ligne à NULL est
+-- aujourd'hui silencieusement absente du compteur public de voyageurs.
+DO $$
+DECLARE n_test bigint; n_option bigint;
+BEGIN
+  SELECT count(*) FILTER (WHERE is_test IS NULL),
+         count(*) FILTER (WHERE is_option IS NULL)
+    INTO n_test, n_option FROM public.booked_dates;
+  RAISE NOTICE 'booked_dates avant backfill : is_test NULL = %, is_option NULL = %', n_test, n_option;
+END $$;
+
+-- =========================================================================
+-- 1. Drapeau `deleted` sur les 6 tables qui ne l'ont pas
+-- =========================================================================
+-- travel_dates et booked_dates l'ont déjà (NOT NULL DEFAULT false).
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'date_notes', 'date_attachments', 'date_invoices', 'voyage_margins',
+    'activecampaign_deals', 'activecampaign_clients'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      RAISE NOTICE 'table % absente, ignorée', t;
+      CONTINUE;
+    END IF;
+    EXECUTE format('ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS deleted boolean', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 2. Quatuor d'audit sur les 8 tables
+-- =========================================================================
+-- deleted_batch est informatif : la restauration s'appuie sur
+-- (travel_date_id, deleted_reason) et non sur le batch, pour qu'une cascade
+-- partielle ayant produit deux batchs se restaure quand même complètement.
+-- Le batch sert à afficher « 12 réservations seront restaurées » et à auditer.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+    'date_invoices', 'voyage_margins', 'activecampaign_deals', 'activecampaign_clients'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format('ALTER TABLE public.%I
+        ADD COLUMN IF NOT EXISTS deleted_at     timestamptz,
+        ADD COLUMN IF NOT EXISTS deleted_by     text,
+        ADD COLUMN IF NOT EXISTS deleted_reason text,
+        ADD COLUMN IF NOT EXISTS deleted_batch  uuid', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 3. Backfill + NOT NULL DEFAULT false sur le drapeau canonique
+-- =========================================================================
+-- Sans le NOT NULL, `.eq('deleted', false)` laisserait silencieusement tomber
+-- les lignes à NULL — exactement la logique ternaire qui casse déjà
+-- is_test / is_option (voir section 4).
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+    'date_invoices', 'voyage_margins', 'activecampaign_deals', 'activecampaign_clients'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format('UPDATE public.%I SET deleted = false WHERE deleted IS NULL', t);
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN deleted SET DEFAULT false', t);
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN deleted SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 4. Les deux pièges NULL préexistants sur booked_dates
+-- =========================================================================
+-- is_test est nullable, et assign-deal.post.js écrivait `is_option || null`
+-- (NULL littéral). Corrigé côté code en même temps que cette migration.
+UPDATE public.booked_dates SET is_test   = false WHERE is_test   IS NULL;
+UPDATE public.booked_dates SET is_option = false WHERE is_option IS NULL;
+ALTER TABLE public.booked_dates
+    ALTER COLUMN is_test   SET DEFAULT false,
+    ALTER COLUMN is_test   SET NOT NULL,
+    ALTER COLUMN is_option SET DEFAULT false,
+    ALTER COLUMN is_option SET NOT NULL;
+
+-- =========================================================================
+-- 5. Cohérence des tombstones
+-- =========================================================================
+-- Asymétrique volontairement : permissif côté `false` pour que le backfill
+-- ci-dessus et toute restauration (qui remet le quatuor à NULL) passent,
+-- contraignant côté `true` pour forcer chaque suppression à passer par
+-- server/utils/softDelete.js plutôt que par un `.update({ deleted: true })` nu.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+    'date_invoices', 'voyage_margins', 'activecampaign_deals', 'activecampaign_clients'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format(
+      'ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I', t, t || '_tombstone_chk');
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD CONSTRAINT %I
+         CHECK (deleted = false OR (deleted_at IS NOT NULL AND deleted_reason IS NOT NULL))',
+      t, t || '_tombstone_chk');
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 6. Énumération des raisons
+-- =========================================================================
+--   manual              action opérateur BMS
+--   cascade_travel_date enfant supprimé PARCE QUE sa date parente l'a été.
+--                       C'est cette valeur qui rend la restauration correcte :
+--                       restaurer une date ne restaure QUE ses enfants en cascade,
+--                       jamais ceux que l'opérateur avait supprimés un par un avant.
+--   ac_deal_deleted     webhook ac/dealDelete
+--   ac_deal_trashed     webhook ac/dealUpdate, branche group === '3' (Corbeille)
+--   ac_deal_lost        webhook ac/dealUpdate, statut Perdu / Supprimé
+--   ac_contact_deleted  webhook ac/contactDelete
+--   purge               réservé au futur job de purge
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+    'date_invoices', 'voyage_margins', 'activecampaign_deals', 'activecampaign_clients'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format(
+      'ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I', t, t || '_deleted_reason_chk');
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD CONSTRAINT %I
+         CHECK (deleted_reason IS NULL OR deleted_reason IN (
+           ''manual'', ''cascade_travel_date'', ''ac_deal_deleted'', ''ac_deal_trashed'',
+           ''ac_deal_lost'', ''ac_contact_deleted'', ''purge''))',
+      t, t || '_deleted_reason_chk');
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 7. Index partiels sur les chemins chauds
+-- =========================================================================
+-- Le code applique systématiquement `.eq('deleted', false)` : ces prédicats
+-- correspondent exactement à cette forme (c'est pourquoi on standardise sur
+-- .eq() plutôt que sur .not('deleted','is',true) côté application).
+CREATE INDEX IF NOT EXISTS booked_dates_travel_date_active_idx
+    ON public.booked_dates (travel_date_id) WHERE deleted = false;
+
+-- Le chemin « réservations payantes » : departures.js, margins.js, les dashboards.
+CREATE INDEX IF NOT EXISTS booked_dates_travel_date_paid_active_idx
+    ON public.booked_dates (travel_date_id) WHERE deleted = false AND booked_places > 0;
+
+CREATE INDEX IF NOT EXISTS travel_dates_slug_departure_active_idx
+    ON public.travel_dates (travel_slug, departure_date) WHERE deleted = false;
+
+CREATE INDEX IF NOT EXISTS travel_dates_departure_id_active_idx
+    ON public.travel_dates (departure_id) WHERE deleted = false AND departure_id IS NOT NULL;
+
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['date_notes', 'date_attachments', 'date_invoices'] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS %I ON public.%I (travel_date_id) WHERE deleted = false',
+      t || '_date_active_idx', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 8. Vérification
+-- =========================================================================
+-- Attendu : 5 colonnes sur chacune des 8 tables (deleted + le quatuor).
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT table_name, count(*) AS n FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND column_name IN ('deleted', 'deleted_at', 'deleted_by', 'deleted_reason', 'deleted_batch')
+      AND table_name IN ('travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+                         'date_invoices', 'voyage_margins', 'activecampaign_deals',
+                         'activecampaign_clients')
+    GROUP BY 1 ORDER BY 1
+  LOOP
+    RAISE NOTICE 'soft delete : % -> % colonnes%', r.table_name, r.n,
+      CASE WHEN r.n = 5 THEN '' ELSE '  <-- ATTENDU 5' END;
+  END LOOP;
+END $$;
+
+-- La FK date_invoices -> travel_dates ON DELETE CASCADE est conservée
+-- (20260530120000_margins_and_invoices.sql). Elle devient dormante puisque plus
+-- aucune travel_dates n'est supprimée physiquement, et reste la bonne sémantique
+-- pour le futur job de purge — qui devra vider les objets Storage AVANT de
+-- supprimer les lignes, sinon les buckets date-invoices / date-attachments
+-- accumulent des fichiers orphelins.


### PR DESCRIPTION
## Contexte

Toutes les suppressions du projet étaient des `DELETE` physiques — d'où les conflits et erreurs. Les colonnes `deleted` existaient déjà sur `travel_dates` et `booked_dates` mais **rien ne les écrivait** : seules 4 lectures les filtraient, de façon incohérente.

Trois pathologies concrètes trouvées pendant l'exploration, toutes corrigées ici :

1. **`booked.get.js` supprimait en dur pendant un simple GET.** Le `catch` fabriquait `{ email: '' }`, donc une panne ActiveCampaign transitoire était indistinguable d'un deal réellement sans email : **charger la page BMS d'une date pendant une panne AC détruisait des réservations et réécrivait `booked_seat`.**
2. **Un deal passé « Perdu » supprimait la ligne.** Si le client payait ensuite, l'`update` par `deal_id` ne trouvait rien et l'erreur n'était qu'un `console.error` : argent encaissé, réservation disparue, personne prévenu.
3. **Aucun chemin de retour propre.** Le doublon sur `UNIQUE(deal_id)` était détecté en comparant le **texte** du message d'erreur Postgres.

## Le point structurant

`booked_dates` **garde `UNIQUE(deal_id)`** : un deal = **une ligne physique à vie**. Une ré-assignation *ressuscite* la ligne (`booking.upsertBookedDateForDeal`) au lieu d'en insérer une seconde.

C'est délibéré : le `booked_id` est embarqué dans les liens de paiement (`/checkout?booked_id=…`) poussés dans ActiveCampaign. Créer une nouvelle ligne à chaque assignation casserait tous les liens déjà envoyés aux clients. L'historique reste tracé dans `date_activity_log`.

Effet de bord agréable : les 3 retries du funnel tombent maintenant sur un chemin idempotent au lieu d'un 409.

## Contenu

| Commit | Portée |
|---|---|
| `feat(db)` | Migration : drapeau `deleted` + quatuor d'audit sur 8 tables, CHECK de cohérence, énumération des raisons, index partiels. Colonnes miroir côté dashboard. |
| `feat(api)` | `softDelete.js`, `upsertBookedDateForDeal`, balayage des lectures, cascade, webhooks, `slack.js`. |
| `feat(bms)` | Corbeille centralisée + restauration, filtres « Supprimés » par bloc. |

**Nouvel écran `/booking-management/trash`** : dates, réservations et deals supprimés, avec qui / quand / **pourquoi** (raison traduite en clair, donc on distingue une action manuelle d'une bascule automatique AC).

## Pièges traités

- **`cleanupDepartureDealIfEmpty`** : sa sonde supposait la ligne *physiquement absente*. Un tombstone garde `booked_places > 0` → sans filtre, le deal de départ pipeline 4 n'aurait plus **jamais** été nettoyé.
- **`UNIQUE(departure_id)`** : la cascade remet `departure_id` à NULL, sinon le tombstone squatte le deal AC à vie.
- **`voyage_margins`** : l'upsert inclut `softDelete.clear()`. Sans ça, `ON CONFLICT DO UPDATE` écrit dans la pierre tombale — l'opérateur saisit une marge, voit « enregistré », et elle reste invisible pour toujours en faussant tous les calculs du voyage.
- **`duplicate.post.js`** : strippe les colonnes de soft delete, sinon dupliquer une date supprimée produisait une date invisible sans erreur.
- **Miroir dashboard** : `mirror-sync` upsert la ligne prod brute, une colonne inconnue renvoie `PGRST204` et arrête *toute* la synchro analytique en silence. Les colonnes ont été ajoutées côté dashboard.
- **Objets Storage conservés** : une pièce jointe ou une facture restaurée retrouve son fichier. Contrepartie : les buckets grossissent, à traiter dans un futur job de purge.

## Vérifications

- Cycle **suppression → restauration** joué de bout en bout sur une date jetable : cascade (note + facture en `cascade_travel_date`), date absente des lectures par défaut et du flux public, puis restauration → quatuor d'audit remis à `null`, enfants revenus, `booked_seat` recalculé.
- Restauration rejouée **depuis l'écran Corbeille**.
- Piège `voyage_margins` vérifié corrigé sur un slug isolé.
- `npx eslint` sur les 66 fichiers touchés : **0 erreur introduite** (baseline faite contre `HEAD`).

## À savoir avant de merger

- **La migration SQL est déjà appliquée en prod** (vérifié : les 5 colonnes sont présentes sur `travel_dates` et `booked_dates`). Elle est idempotente (`IF NOT EXISTS` partout).
- ⚠️ **À vérifier côté Supabase prod** : que chaque trigger `mirror_sync_*` se déclenche bien sur **UPDATE** et pas seulement INSERT/DELETE — un soft delete est un UPDATE, sinon les suppressions n'atteignent jamais le miroir et les dashboards continuent de compter des réservations supprimées.

## Limites assumées

- Les onglets **Réservations** et **Deals** de la corbeille n'ont pas pu être exercés avec de vraies lignes (rien de supprimé dans ces tables aujourd'hui ; en créer demanderait de passer par ActiveCampaign ou de masquer une vraie ligne de reporting). Routes et états vides vérifiés.
- La règle « un enfant supprimé manuellement *avant* sa date ne remonte pas avec elle » n'a pas été jouée end-to-end : les endpoints de suppression de note et de facture exigent une session BMS que le serveur de dev n'a pas. Elle est garantie par construction.
- Il reste **un** `DELETE` physique, `margins.js:135` sur `voyage_margin_seasons` : hors périmètre, mais il contourne le soft delete car la FK `voyage_margins.season_id` est en `ON DELETE CASCADE`. À traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
