### PR TITLE
fix(margins): soft delete des saisons — la dernière suppression physique

### DIFF
--- a/server/api/v1/booking/margins/[slug]/seasons.put.js
+++ b/server/api/v1/booking/margins/[slug]/seasons.put.js
@@ -1,8 +1,10 @@
 import { defineEventHandler, readBody, createError } from 'h3'
 
 // Replace-all: the editor sends the voyage's complete season list.
-// Seasons dropped from the payload are deleted, cascading to their voyage_margins
-// rows — amounts attached to a removed period have no meaning left.
+// Seasons dropped from the payload are soft-deleted, and their voyage_margins rows
+// with them (reason 'cascade_margin_season') — amounts attached to a removed period
+// have no meaning left, mais rien n'est détruit : re-soumettre la saison avec son id
+// remonte la saison ET ses montants.
 //
 // Overlap and DD/MM validity are enforced in margins.replaceSeasonsForVoyage,
 // which tags those errors with statusCode 400.

--- a/server/api/v1/booking/margins/index.get.js
+++ b/server/api/v1/booking/margins/index.get.js
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
       supabase.from('voyage_margins').select('voyage_slug, pax, year, season_id, margin_per_traveler').eq('deleted', false),
     ),
     fetchAllPaginated(() =>
-      supabase.from('voyage_margin_seasons').select('id, voyage_slug, label, sort_order'),
+      supabase.from('voyage_margin_seasons').select('id, voyage_slug, label, sort_order').eq('deleted', false),
     ),
     fetchAllPaginated(() =>
       supabase.from('voyage_margin_settings').select('voyage_slug, config_mode, child_margin_delta'),

--- a/server/utils/margins.js
+++ b/server/utils/margins.js
@@ -101,6 +101,7 @@ const getSeasonsForVoyage = async (voyageSlug) => {
     .from('voyage_margin_seasons')
     .select('id, label, start_month, start_day, end_month, end_day, sort_order')
     .eq('voyage_slug', voyageSlug)
+    .eq('deleted', false)
     .order('sort_order', { ascending: true })
 
   if (error) throw error
@@ -108,9 +109,15 @@ const getSeasonsForVoyage = async (voyageSlug) => {
 }
 
 // Replace-all semantics: the editor sends the full season list for the voyage.
-// Seasons dropped from the payload are deleted, which cascades to their
-// voyage_margins rows (ON DELETE CASCADE) — the amounts of a removed season
-// have no meaning left.
+// Seasons dropped from the payload are soft-deleted, and their voyage_margins rows
+// go with them under reason `cascade_margin_season` — the amounts of a removed
+// period have no meaning left, but they stay restorable.
+//
+// La cascade est faite ICI, à la main, et surtout pas laissée à la FK
+// voyage_margins.season_id ON DELETE CASCADE : un DELETE physique sur la saison
+// emporterait les lignes voyage_margins pour de bon, drapeau `deleted` compris.
+// C'est exactement ce que faisait cette fonction avant le passage au soft delete —
+// la seule voie par laquelle des marges pouvaient encore être détruites.
 const replaceSeasonsForVoyage = async (voyageSlug, seasons, editorEmail) => {
   if (!Array.isArray(seasons)) throw new Error('seasons must be an array')
 
@@ -131,11 +138,42 @@ const replaceSeasonsForVoyage = async (voyageSlug, seasons, editorEmail) => {
     throw err
   }
 
+  const user = editorEmail ? { email: editorEmail } : null
+  const batch = softDelete.newBatch()
   const keptIds = normalized.map(s => s.id).filter(Boolean)
-  let deleteQuery = supabase.from('voyage_margin_seasons').delete().eq('voyage_slug', voyageSlug)
-  if (keptIds.length) deleteQuery = deleteQuery.not('id', 'in', `(${keptIds.join(',')})`)
-  const { error: deleteError } = await deleteQuery
-  if (deleteError) throw deleteError
+
+  // L'état réel en base, tombstones compris — il faut les deux moitiés : ce qui
+  // disparaît du payload (à supprimer) et ce qui y revient alors qu'il était
+  // supprimé (à ressusciter, montants compris).
+  const { data: existing, error: existingError } = await supabase
+    .from('voyage_margin_seasons')
+    .select('id, deleted')
+    .eq('voyage_slug', voyageSlug)
+  if (existingError) throw existingError
+
+  const droppedIds = (existing || []).filter(s => !s.deleted && !keptIds.includes(s.id)).map(s => s.id)
+  const revivedIds = (existing || []).filter(s => s.deleted && keptIds.includes(s.id)).map(s => s.id)
+
+  if (droppedIds.length) {
+    // Enfants d'abord, parent ensuite — même raison que la cascade des dates
+    // (index.delete.js) : la séquence n'est pas transactionnelle, et une
+    // exécution partielle doit ressembler à « montants masqués sous une saison
+    // vivante » (visible et réparable) plutôt qu'à « montants vivants sous une
+    // saison morte » (invisible et faux).
+    const removedMargins = await softDelete.remove(
+      'voyage_margins',
+      q => q.in('season_id', droppedIds),
+      { user, reason: softDelete.REASONS.CASCADE_MARGIN_SEASON, batch },
+    )
+    if (removedMargins.error) throw new Error(removedMargins.error)
+
+    const removedSeasons = await softDelete.remove(
+      'voyage_margin_seasons',
+      q => q.in('id', droppedIds),
+      { user, reason: softDelete.REASONS.MANUAL, batch },
+    )
+    if (removedSeasons.error) throw new Error(removedSeasons.error)
+  }
 
   if (!normalized.length) return []
 
@@ -149,6 +187,11 @@ const replaceSeasonsForVoyage = async (voyageSlug, seasons, editorEmail) => {
     voyage_slug: voyageSlug,
     updated_at: new Date().toISOString(),
     updated_by: editorEmail || null,
+    // Même piège que dans upsertMarginForVoyage : sans ça, un ON CONFLICT DO
+    // UPDATE sur une saison supprimée (onglet resté ouvert, édition
+    // concurrente) écrirait dans la pierre tombale sans la lever — la saison
+    // reviendrait « enregistrée » et resterait invisible.
+    ...softDelete.clear(),
   })
 
   const RETURNING = 'id, label, start_month, start_day, end_month, end_day, sort_order'
@@ -178,6 +221,18 @@ const replaceSeasonsForVoyage = async (voyageSlug, seasons, editorEmail) => {
       .select(RETURNING)
     if (error) throw error
     saved.push(...(data || []))
+  }
+
+  // Symétrique exact de la cascade ci-dessus : une saison qui remonte ramène les
+  // montants partis AVEC elle, et seulement ceux-là. Une cellule que l'opérateur
+  // avait supprimée à la main garde sa raison 'manual' et reste masquée — même
+  // règle que la restauration d'une date de départ.
+  if (revivedIds.length) {
+    const restored = await softDelete.restore(
+      'voyage_margins',
+      q => q.in('season_id', revivedIds).eq('deleted_reason', softDelete.REASONS.CASCADE_MARGIN_SEASON),
+    )
+    if (restored.error) throw new Error(restored.error)
   }
 
   return saved.sort((a, b) => a.sort_order - b.sort_order)

--- a/server/utils/softDelete.js
+++ b/server/utils/softDelete.js
@@ -17,6 +17,12 @@ export const DELETE_REASONS = {
   // rend la restauration correcte : restaurer une date ne restaure que ses
   // enfants en cascade, jamais ceux supprimés un par un avant.
   CASCADE_TRAVEL_DATE: 'cascade_travel_date',
+  // Palier de marge supprimé PARCE QUE la saison qui le porte a été retirée de
+  // la liste de l'éditeur. Distinct de CASCADE_TRAVEL_DATE à dessein : les deux
+  // restaurations ne passent pas par le même chemin (re-création de la saison
+  // d'un côté, restore.post.js de l'autre), et les confondre ferait remonter des
+  // montants de saison en restaurant une date.
+  CASCADE_MARGIN_SEASON: 'cascade_margin_season',
   AC_DEAL_DELETED: 'ac_deal_deleted',
   AC_DEAL_TRASHED: 'ac_deal_trashed',
   AC_DEAL_LOST: 'ac_deal_lost',

--- a/supabase/migrations/20260801120000_soft_delete_margin_seasons.sql
+++ b/supabase/migrations/20260801120000_soft_delete_margin_seasons.sql
@@ -1,0 +1,147 @@
+-- Soft delete sur voyage_margin_seasons — la dernière fuite du modèle.
+--
+-- 20260801090000_soft_delete.sql a mis voyage_margins en soft delete, mais a laissé
+-- voyage_margin_seasons en dehors : c'était la seule table à ne jamais être supprimée
+-- depuis le BMS… en apparence. En réalité replaceSeasonsForVoyage (server/utils/margins.js)
+-- faisait un DELETE physique, et
+--
+--   voyage_margins.season_id -> voyage_margin_seasons(id) ON DELETE CASCADE
+--   (20260731120000_margins_v3.sql)
+--
+-- propageait ce DELETE aux montants de la saison. Retirer une saison de la liste
+-- dans l'éditeur détruisait donc PHYSIQUEMENT des lignes voyage_margins — la table
+-- même que 090000 venait de rendre restaurable. Le drapeau `deleted` était court-circuité
+-- par la base, sans trace ni retour possible.
+--
+-- Cette migration ferme la brèche côté schéma ; le DELETE côté code est remplacé par
+-- softDelete.remove() dans le même commit. Elle est PUREMENT ADDITIVE : toutes les lignes
+-- existantes restent `deleted = false`.
+--
+-- La table n'est PAS répliquée vers le projet dashboard (supabase/dashboard/01_target_tables.sql
+-- ne la connaît pas), donc contrairement à 090000, aucun ajout miroir n'est requis avant
+-- de jouer ceci en prod.
+
+-- =========================================================================
+-- 1. Drapeau `deleted` + quatuor d'audit
+-- =========================================================================
+-- Même forme que 090000 (boucle FOREACH sur une liste d'une table) pour que les deux
+-- migrations restent lisibles côte à côte et que la liste s'étende sans réécriture.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['voyage_margin_seasons'] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      RAISE NOTICE 'table % absente, ignorée', t;
+      CONTINUE;
+    END IF;
+    EXECUTE format('ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS deleted boolean', t);
+    EXECUTE format('ALTER TABLE public.%I
+        ADD COLUMN IF NOT EXISTS deleted_at     timestamptz,
+        ADD COLUMN IF NOT EXISTS deleted_by     text,
+        ADD COLUMN IF NOT EXISTS deleted_reason text,
+        ADD COLUMN IF NOT EXISTS deleted_batch  uuid', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 2. Backfill + NOT NULL DEFAULT false
+-- =========================================================================
+-- Sans le NOT NULL, le `.eq('deleted', false)` ajouté à getSeasonsForVoyage ferait
+-- disparaître toutes les saisons existantes (une colonne NULL n'est jamais égale à false).
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['voyage_margin_seasons'] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format('UPDATE public.%I SET deleted = false WHERE deleted IS NULL', t);
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN deleted SET DEFAULT false', t);
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN deleted SET NOT NULL', t);
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 3. Cohérence des tombstones
+-- =========================================================================
+-- Asymétrique comme dans 090000 : permissif côté `false` (backfill, restauration),
+-- contraignant côté `true` pour forcer le passage par server/utils/softDelete.js.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['voyage_margin_seasons'] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format(
+      'ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I', t, t || '_tombstone_chk');
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD CONSTRAINT %I
+         CHECK (deleted = false OR (deleted_at IS NOT NULL AND deleted_reason IS NOT NULL))',
+      t, t || '_tombstone_chk');
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 4. Nouvelle raison : cascade_margin_season
+-- =========================================================================
+-- Un palier de marge supprimé PARCE QUE la saison qui le porte a été retirée de la
+-- liste de l'éditeur. Volontairement distinct de cascade_travel_date : ce n'est pas une
+-- date de départ qui tombe, et la restauration ne passe pas par le même chemin
+-- (re-création de la saison plutôt que restore.post.js). Les mélanger ferait remonter
+-- des montants de saison en restaurant une date, et inversement.
+--
+-- Le CHECK est recréé sur les 8 tables de 090000 + voyage_margin_seasons, pour que
+-- l'énumération reste identique partout — c'est ce qui permet de lire une raison sans
+-- se demander de quelle table elle vient.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'travel_dates', 'booked_dates', 'date_notes', 'date_attachments',
+    'date_invoices', 'voyage_margins', 'activecampaign_deals', 'activecampaign_clients',
+    'voyage_margin_seasons'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN CONTINUE; END IF;
+    EXECUTE format(
+      'ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I', t, t || '_deleted_reason_chk');
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD CONSTRAINT %I
+         CHECK (deleted_reason IS NULL OR deleted_reason IN (
+           ''manual'', ''cascade_travel_date'', ''cascade_margin_season'',
+           ''ac_deal_deleted'', ''ac_deal_trashed'', ''ac_deal_lost'',
+           ''ac_contact_deleted'', ''purge''))',
+      t, t || '_deleted_reason_chk');
+  END LOOP;
+END $$;
+
+-- =========================================================================
+-- 5. Index partiels
+-- =========================================================================
+-- getSeasonsForVoyage lit toujours (voyage_slug) WHERE deleted = false.
+CREATE INDEX IF NOT EXISTS voyage_margin_seasons_slug_active_idx
+    ON public.voyage_margin_seasons (voyage_slug) WHERE deleted = false;
+
+-- La cascade tire sur (season_id) : voyage_margins_season_id_idx (margins_v3) la sert
+-- déjà, mais la restauration filtre en plus sur la raison.
+CREATE INDEX IF NOT EXISTS voyage_margins_season_cascade_idx
+    ON public.voyage_margins (season_id)
+    WHERE deleted = true AND deleted_reason = 'cascade_margin_season';
+
+-- =========================================================================
+-- 6. Vérification
+-- =========================================================================
+-- Attendu : 5 colonnes (deleted + le quatuor) sur voyage_margin_seasons.
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT count(*) INTO n FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'voyage_margin_seasons'
+    AND column_name IN ('deleted', 'deleted_at', 'deleted_by', 'deleted_reason', 'deleted_batch');
+  RAISE NOTICE 'soft delete : voyage_margin_seasons -> % colonnes%', n,
+    CASE WHEN n = 5 THEN '' ELSE '  <-- ATTENDU 5' END;
+END $$;
+
+-- La FK voyage_margins.season_id -> voyage_margin_seasons(id) ON DELETE CASCADE est
+-- CONSERVÉE, comme celle de date_invoices -> travel_dates. Elle devient dormante :
+-- plus aucune saison n'est supprimée physiquement, donc elle ne se déclenche jamais en
+-- fonctionnement normal. Elle reste la bonne sémantique pour le futur job de purge —
+-- purger une saison doit bien emporter ses montants — et un garde-fou si une suppression
+-- physique était faite à la main depuis l'éditeur SQL.


### PR DESCRIPTION
Suite de #250. `replaceSeasonsForVoyage` faisait encore un `DELETE` physique sur `voyage_margin_seasons` — le dernier `.delete()` de `server/`.

## Le vrai problème n'était pas la saison

Il était dans la FK posée par `margins_v3` :

```sql
voyage_margins.season_id -> voyage_margin_seasons(id) ON DELETE CASCADE
```

Retirer une saison de la liste dans l'éditeur **détruisait physiquement les lignes `voyage_margins` de cette saison** — la table même que `20260801090000` venait de rendre restaurable. Le drapeau `deleted` était court-circuité par la base : pas de pierre tombale, pas de trace, pas de retour possible. Un opérateur qui retirait une saison par erreur perdait les montants pour de bon.

## Ce que fait cette PR

**Migration** `20260801120000_soft_delete_margin_seasons.sql`, calquée sur `20260801090000` (bloc `DO $$ FOREACH`, backfill + `NOT NULL DEFAULT false`, `CHECK` tombstone, index partiels). Purement additive. Le `CHECK` des raisons est recréé sur **les 9 tables** (les 8 de 090000 + `voyage_margin_seasons`) : sans ça l'écriture de la cascade violerait la contrainte sur `voyage_margins`.

**Nouvelle raison `cascade_margin_season`**, volontairement distincte de `cascade_travel_date`. Les deux restaurations n'empruntent pas le même chemin — re-création de la saison d'un côté, `restore.post.js` de l'autre. Les confondre ferait remonter des montants de saison en restaurant une date de départ, et inversement ; le filtre par raison est précisément ce qui rend la restauration correcte.

**La cascade est faite explicitement** dans `margins.js`, enfants avant parent et sous un `batch` commun, comme dans `index.delete.js`. La FK `ON DELETE CASCADE` reste en place mais devient dormante, comme celle de `date_invoices` → `travel_dates` : elle reste la bonne sémantique pour le futur job de purge, et un garde-fou si une suppression physique était faite à la main depuis l'éditeur SQL.

**Le piège de l'upsert** : `...softDelete.clear()` ajouté sur les saisons (même piège que celui corrigé dans `upsertMarginForVoyage`), **plus** une restauration symétrique des `voyage_margins`. Lever la pierre tombale de la saison sans remonter ses montants aurait produit un état à moitié restauré — pire que le bug d'origine.

**Lectures filtrées** : `getSeasonsForVoyage` et `index.get.js`. Ce sont les deux seules ; `dashboard/[slug].get.js` et `[slug].get.js` passent par le helper.

## Vérification

Migration appliquée sur BackOffice-PROD, puis 18 assertions bout en bout via le serveur de dev sur un slug isolé (`zz-test-soft-delete`, purgé après coup), avec lecture **brute** en PostgREST pour distinguer « masqué » de « détruit » :

```
ok  la ligne voyage_margins existe toujours en base
ok    -> montant intact — 500
ok    -> deleted = true, reason = cascade_margin_season
ok    -> même batch que la saison (cascade groupée)
ok  saison ressuscitée sur le même id (pas de doublon)
ok  marge de nouveau visible avec son montant
ok  pierre tombale de la saison levée
ok  cellule supprimée manuellement reste masquée (reason manual)
```

Le filtre de `index.get.js` a aussi été vérifié séparément, sur un voyage gardé dans la liste par une ligne « Défaut » : `season_count` passe de 1 à 0, `season_labels` se vide, le statut repasse de `partial` (« saison non renseignée ») à `configured`, et la ligne reste en base avec `deleted = true`.

Lint : les `no-undef` sur `softDelete` sont l'auto-import nitro, déjà présents au baseline.

## Pour le relecteur

- **Base `dev` et non `main`**, pour rester aligné avec #250 : `main` ne contient pas encore le soft delete.
- **La migration est déjà jouée en prod** (colonnes + CHECK). À rejouer sur les autres environnements avant déploiement.
- Contrairement à 090000, **aucun ajout miroir n'est requis** : `voyage_margin_seasons` n'est pas répliquée vers le projet dashboard.

Deux limites connues, hors périmètre :
- **Pas de chemin de restauration dans l'UI.** L'éditeur ne renvoie que les saisons actives, donc re-créer une saison supprimée génère un nouvel `uuid` et les anciens montants restent masqués. Le `revivedIds` ajouté ici ne couvre que l'onglet resté ouvert et l'édition concurrente. Même trou que pour `voyage_margins`, dont les suppressions n'apparaissent pas non plus dans `/booking-management/trash`.
- **`voyage_margin_settings`** n'a pas de soft delete — aucun chemin de suppression ne l'atteint aujourd'hui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)