### PR TITLE
fix(departures): conserver le deal Gestions Départs et son suivi quand la date se vide

### DIFF
--- a/server/api/v1/ac/webhooks/dealUpdate.post.js
+++ b/server/api/v1/ac/webhooks/dealUpdate.post.js
@@ -142,7 +142,7 @@ export default defineEventHandler(async (event) => {
           await booking.recomputeBookedSeatAndStatus(travel_date_id)
           console.log('Booked places updated successfully, travel_date_id:', travel_date_id)
 
-          // Remove departure record deal if no paying clients remain
+          // Deal de départ mis en veille s'il ne reste aucun payant (jamais supprimé)
           await departures.cleanupDepartureDealIfEmpty(travel_date_id)
 
           await logDateActivity(travel_date_id, AC_USER, 'deal_removed', {
@@ -184,7 +184,7 @@ export default defineEventHandler(async (event) => {
           await booking.recomputeBookedSeatAndStatus(travel_date_id)
           console.log('Booked places updated successfully, travel_date_id:', travel_date_id)
 
-          // Remove departure record deal if no paying clients remain
+          // Deal de départ mis en veille s'il ne reste aucun payant (jamais supprimé)
           await departures.cleanupDepartureDealIfEmpty(travel_date_id)
 
           await logDateActivity(travel_date_id, AC_USER, 'deal_removed', {

--- a/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/assign-deal.post.js
@@ -125,7 +125,8 @@ export default defineEventHandler(async (event) => {
   const recomputeErr = recomputeResults.find(r => r?.error)
   if (recomputeErr) throw createError({ statusCode: 500, statusMessage: recomputeErr.error })
 
-  // Si la ligne a quitté une autre date, celle-ci peut ne plus avoir de payant.
+  // Si la ligne a quitté une autre date, celle-ci peut ne plus avoir de payant :
+  // son deal de départ passe en veille, sans être supprimé.
   if (res.moved && res.previous?.travel_date_id) {
     await departures.cleanupDepartureDealIfEmpty(res.previous.travel_date_id)
   }

--- a/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId].delete.js
+++ b/server/api/v1/booking/[slug]/date/[dateId]/booked/[bookedId].delete.js
@@ -30,7 +30,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: recompute.error })
   }
 
-  // Remove departure record deal if no paying clients remain
+  // Met le deal de départ en veille s'il ne reste aucun payant. Il n'est PAS
+  // supprimé : une réaffectation du même pax doit retrouver son suivi AC.
   await departures.cleanupDepartureDealIfEmpty(travel_date_id)
 
   await logDateActivity(travel_date_id, bookingUser, 'deal_removed', { deal_id: bookedRow.deal_id, booked_id: bookedId })

--- a/server/utils/departures.js
+++ b/server/utils/departures.js
@@ -224,9 +224,24 @@ const handlePaymentForDeparture = async (bookedDate, travelTitle, contactId) => 
 }
 
 /**
- * After a booked_date is deleted, checks whether any paying clients remain
- * on the same travel date. If none do and a departure record deal exists,
- * deletes it from ActiveCampaign and clears travel_dates.departure_id.
+ * Après la suppression d'une réservation, vérifie s'il reste des clients payants
+ * sur la même date. S'il n'en reste aucun, le deal de départ (pipeline 4) est
+ * MIS EN VEILLE — il n'est jamais supprimé.
+ *
+ * Cette fonction appelait activecampaign.deleteDeal() et remettait
+ * travel_dates.departure_id à null. Une désaffectation suivie d'une
+ * ré-affectation — rare, mais c'est le quotidien des dossiers sur-mesure à un
+ * seul payant, où retirer le pax vide la date — détruisait donc le deal AC avec
+ * ses notes, tâches, rappels et propriétaire, puis en recréait un vierge. L'OPS
+ * repartait de zéro sur le suivi.
+ *
+ * On garde désormais le deal et son departure_id : à la ré-affectation,
+ * getOrCreateDepartureDeal retombe sur le même deal et handlePaymentForDeparture
+ * le rallume au bon stage avec les bons totaux. Aucun doublon, aucun ménage.
+ *
+ * Contrepartie assumée : une date qui ne se remplit jamais garde un deal à 0 pax
+ * en « Départ à confirmer ». La note horodatée le rend identifiable pour un
+ * nettoyage manuel dans AC.
  *
  * Must be called AFTER the booked_date row has already been removed.
  */
@@ -244,7 +259,7 @@ const cleanupDepartureDealIfEmpty = async (travelDateId) => {
     // ligne était PHYSIQUEMENT absente. Une réservation soft-deleted garde
     // booked_places > 0 (la restauration doit être exacte), donc sans ce filtre la
     // sonde conclut « il reste des clients payants » et le deal de départ
-    // pipeline 4 n'est plus jamais nettoyé.
+    // pipeline 4 n'est jamais mis en veille.
     const { data: remainingPaid } = await supabase
       .from('booked_dates')
       .select('id')
@@ -255,23 +270,57 @@ const cleanupDepartureDealIfEmpty = async (travelDateId) => {
 
     if (remainingPaid && remainingPaid.length > 0) return
 
-    // No paying clients left — remove the departure record deal
-    console.log(`cleanupDepartureDealIfEmpty: no paid bookings left for travel_date ${travelDateId}, deleting departure deal ${travelDate.departure_id}`)
+    const idleStage = String(STAGES.DEPART_A_CONFIRMER)
 
+    // État courant du deal : sert à la fois de sonde d'existence et de garde
+    // d'idempotence. Les webhooks AC (dealDelete, dealUpdate) peuvent tirer
+    // plusieurs fois sur la même date ; sans ce garde on empilerait une note à
+    // chaque passage.
+    let currentStage = null
+    let currentValue = 0
     try {
-      await activecampaign.deleteDeal(travelDate.departure_id)
+      const { deal } = await activecampaign.getDealById(travelDate.departure_id)
+      currentStage = deal?.stage ? String(deal.stage) : null
+      currentValue = Number(deal?.value || 0)
     }
     catch (err) {
-      console.error('cleanupDepartureDealIfEmpty: failed to delete AC departure deal:', err.message)
+      if (err.response?.status === 404) {
+        // Deal supprimé à la main dans AC : il n'y a plus d'historique à
+        // protéger, et garder le pointeur ferait échouer toutes les mises à
+        // jour futures. On libère le lien pour qu'un prochain paiement recrée
+        // un deal propre.
+        console.warn(`cleanupDepartureDealIfEmpty: deal de départ ${travelDate.departure_id} absent d'AC, departure_id libéré`)
+        const { error: clearError } = await supabase
+          .from('travel_dates')
+          .update({ departure_id: null })
+          .eq('id', travelDateId)
+        if (clearError) {
+          console.error('cleanupDepartureDealIfEmpty: departure_id non remis à null:', clearError)
+        }
+        return
+      }
+      console.error('cleanupDepartureDealIfEmpty: lecture du deal de départ échouée:', err.message)
+      return
     }
 
-    const { error: clearError } = await supabase
-      .from('travel_dates')
-      .update({ departure_id: null })
-      .eq('id', travelDateId)
+    if (currentStage === idleStage && currentValue === 0) return
 
-    if (clearError) {
-      console.error('cleanupDepartureDealIfEmpty: failed to clear departure_id:', clearError)
+    console.log(`cleanupDepartureDealIfEmpty: plus aucune réservation payante sur la date ${travelDateId}, mise en veille du deal de départ ${travelDate.departure_id}`)
+
+    try {
+      await activecampaign.updateDeal(travelDate.departure_id, {
+        stage: idleStage,
+        value: 0,
+        nbTravelers: 0,
+      })
+      await activecampaign.addNote(travelDate.departure_id, {
+        note: {
+          note: `[BMS] ${dayjs().format('DD/MM/YYYY HH:mm')} — plus aucun voyageur payant sur cette date. Deal conservé (suivi, notes et tâches intacts) : il sera réutilisé si un voyageur est réaffecté.`,
+        },
+      })
+    }
+    catch (err) {
+      console.error('cleanupDepartureDealIfEmpty: mise en veille du deal de départ échouée:', err.message)
     }
   }
   catch (err) {


### PR DESCRIPTION
## Problème

Remonté par une opératrice : après une désaffectation puis une réaffectation d'un pax dans le BMS, le deal de la pipe **Gestions Départs** est recréé à neuf — notes, tâches programmées, rappels et propriétaire sont perdus. Ce matin-là, un paiement a failli être manqué, ce qui aurait pu entraîner l'annulation d'une réservation.

## Cause

`cleanupDepartureDealIfEmpty` supprimait purement et simplement le deal dans AC :

```
Désaffectation du pax → booked/[bookedId].delete.js
  → soft delete de la réservation
  → cleanupDepartureDealIfEmpty(travel_date_id)
  → plus aucune réservation payante sur la date ?
      → activecampaign.deleteDeal(departure_id)   ← deal DÉTRUIT dans AC
      → travel_dates.departure_id = null          ← lien perdu

Réaffectation → assign-deal.post.js
  → handlePaymentForDeparture → getOrCreateDepartureDeal
  → departure_id null → CRÉE un nouveau deal vierge
```

C'est rare parce que ça ne se déclenche que si le pax retiré était le **dernier payant de la date** — donc précisément les dossiers sur-mesure et privatisations à un seul dossier, ceux qui portent le plus de suivi.

Trois autres chemins appelaient le même nettoyage : déplacement vers une autre date (`assign-deal.post.js`) et les webhooks AC `dealDelete` / `dealUpdate`.

## Correctif

Le deal n'est plus jamais supprimé, il est **mis en veille** :

- stage → `DEPART_A_CONFIRMER` (60), `value` et `nbTravelers` → 0
- une note horodatée est ajoutée pour que l'OPS identifie le deal en veille
- `departure_id` est **conservé** : à la réaffectation, `getOrCreateDepartureDeal` retombe sur le même deal et `handlePaymentForDeparture` le rallume au bon stage avec les bons totaux

Résultat : suivi intact, aucun doublon, aucun ménage manuel.

Deux garde-fous :
- **idempotence** — si le deal est déjà en veille, aucune écriture ni note supplémentaire (les webhooks AC peuvent tirer plusieurs fois sur la même date)
- **404 AC** — si le deal a été supprimé à la main dans AC, il n'y a plus d'historique à protéger et `departure_id` est libéré, sinon toutes les mises à jour futures échoueraient sur un pointeur mort

## Périmètre

| Chemin | Avant | Après |
|---|---|---|
| Désaffectation d'un pax | deal GD supprimé | deal conservé, mis en veille |
| Déplacement vers une autre date | deal GD de l'ancienne date supprimé | idem |
| Webhooks AC `dealDelete` / `dealUpdate` | deal GD supprimé | idem |
| Suppression de la date entière | deal GD supprimé | **inchangé** |

La suppression d'une date entière ([index.delete.js](server/api/v1/booking/%5Bslug%5D/date/%5BdateId%5D/index.delete.js)) reste volontairement en l'état : le geste est délibéré, et `travel_dates` porte un `UNIQUE(departure_id)` qu'un tombstone conservant son pointeur squatterait à vie.

## Contrepartie assumée

Une date qui ne se remplit jamais garde un deal à 0 pax en « Départ à confirmer » dans la pipe GD. La note horodatée et le couple stage + 0 voyageur les rendent identifiables d'un coup d'œil pour un nettoyage manuel. Une purge automatique (deals vides depuis plus de 30 jours **et** sans note ni tâche) peut être ajoutée au cron existant [departure-stages.js](server/api/v1/webhooks/booking/departure-stages.js) dans un second temps — volontairement hors de cette PR.

## Vérification

`npx eslint` passe sur les 4 fichiers modifiés. Le comportement AC n'est pas couvert par les tests existants (`server/scripts/test-handle-payment.js` mocke `departures` en entier) — à valider en préprod sur le scénario : payer une date à un seul pax → désaffecter → vérifier que le deal GD existe toujours à 0 pax avec ses notes → réaffecter → vérifier qu'aucun nouveau deal n'a été créé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)