### PR TITLE
fix(tracking): charger GTM/SST au mount plutôt qu'à la première interaction

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -119,59 +119,32 @@ onMounted(() => {
   setTimeout(loadHotjar, 30000)
 })
 
+// GTM/SST is loaded as soon as the app mounts.
+//
+// It used to be deferred to the first user interaction (15s safety net) to keep
+// its ~440KB / ~2.9s of script eval out of the Lighthouse measurement window.
+// That cost us the tracking itself: nothing Google-related was present on
+// initial load, so Tag Assistant / GA4 & Ads "vérifier l'installation" / GTM
+// Preview reported no tag at all, and every visitor who bounced without
+// interacting in under 15s was never counted. Detection and short sessions are
+// worth more than the synthetic perf score.
 onMounted(() => {
-  let gtmLoaded = false
-
-  const loadGtm = () => {
-    if (gtmLoaded || (typeof window !== 'undefined' && window.google_tag_manager)) return
-    gtmLoaded = true
-
-    window.dataLayer = window.dataLayer || []
-    window.dataLayer.push({
-      'gtm.start': new Date().getTime(),
-      'event': 'gtm.js',
-    })
-
-    const script = document.createElement('script')
-    script.async = true
-    script.src = 'https://load.sst.odysway.com/28bwtluuzax.js?5qth5h1=EQVHMiEhWTkoV0kvJ1lSAUVTVERTCBpKFwUDBgINDVkbDhc%3D'
-    document.head.appendChild(script)
-  }
-
   if (config.public.environment !== 'production') {
     return
   }
 
-  // Funnel pages load GTM immediately: add_payment_info fires milliseconds
-  // before window.location.href sends the user to Stripe/Alma, and purchase
-  // fires on a page users often leave in a few seconds. Waiting for the
-  // interaction/15s fallback there loses the event entirely. These pages are
-  // not SEO landing pages, so the Lighthouse budget doesn't apply.
-  const isFunnelPage = path => path.startsWith('/checkout') || path.startsWith('/confirmation')
+  if (window.google_tag_manager) return
 
-  if (isFunnelPage(route.path)) {
-    loadGtm()
-    return
-  }
-
-  watch(() => route.path, (path) => {
-    if (isFunnelPage(path)) loadGtm()
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({
+    'gtm.start': new Date().getTime(),
+    'event': 'gtm.js',
   })
 
-  // GTM/SST is ~440KB transferred + ~2.9s of script eval. Loading via
-  // requestIdleCallback still landed inside the Lighthouse measurement
-  // window on slow 4G. Defer until first user interaction OR a long idle
-  // (15s safety net) so the metrics window stays clean. dataLayer events
-  // queued before this point fire correctly once GTM boots.
-  const gtmEvents = ['mousedown', 'touchstart', 'keydown', 'scroll']
-  const loadGtmOnInteraction = () => {
-    loadGtm()
-    gtmEvents.forEach(event => document.removeEventListener(event, loadGtmOnInteraction))
-  }
-  gtmEvents.forEach((event) => {
-    document.addEventListener(event, loadGtmOnInteraction, { once: true, passive: true })
-  })
-  setTimeout(loadGtm, 15000)
+  const script = document.createElement('script')
+  script.async = true
+  script.src = 'https://load.sst.odysway.com/28bwtluuzax.js?5qth5h1=EQVHMiEhWTkoV0kvJ1lSAUVTVERTCBpKFwUDBgINDVkbDhc%3D'
+  document.head.appendChild(script)
 })
 
 onMounted(() => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,10 +39,9 @@ export default defineNuxtConfig({
         { rel: 'preconnect', href: 'https://cdn.sanity.io', crossorigin: 'anonymous' },
         { rel: 'preconnect', href: 'https://nu6yntji.apicdn.sanity.io', crossorigin: 'anonymous' },
         { rel: 'preconnect', href: 'https://nu6yntji.api.sanity.io', crossorigin: 'anonymous' },
-        // SST/GTM is loaded on first user interaction (see app.vue), so we
-        // only need DNS resolution warm — preconnect would waste the slot
-        // since we don't open a TLS connection until the user interacts.
-        { rel: 'dns-prefetch', href: 'https://load.sst.odysway.com' },
+        // SST/GTM is loaded on mount (see app.vue), so the TLS handshake to
+        // load.sst.odysway.com happens on every page — warm it up front.
+        { rel: 'preconnect', href: 'https://load.sst.odysway.com', crossorigin: 'anonymous' },
         { rel: 'dns-prefetch', href: 'https://sst.odysway.com' },
       ],
       htmlAttrs: {


### PR DESCRIPTION
## Contexte

Signalement : « le gtag n'est plus détecté, on n'a plus de tracking », avec des violations CSP en console mentionnant `gtag/js?id=DUMMY`.

**Les violations CSP ne sont pas la cause.** Ces messages viennent de `tag_assistant_api_bin.js`, c'est-à-dire l'extension Google Tag Assistant qui sonde un ID bidon (`DUMMY`) pour détecter la présence d'un tag. Et le header envoyé en prod est `Content-Security-Policy-Report-Only` : le navigateur logue mais ne bloque rien.

## Cause réelle

`curl https://odysway.com` ne renvoie aucune référence à `googletagmanager.com/gtm.js` ni à `gtag/js` — uniquement l'iframe `<noscript>`.

Le loader GTM était injecté côté client **uniquement au premier `mousedown` / `touchstart` / `keydown` / `scroll`**, ou après un `setTimeout` de 15 s, et depuis le domaine server-side tagging `load.sst.odysway.com`.

Résultat pour les outils de détection Google (Tag Assistant, « vérifier l'installation » GA4/Ads, aperçu GTM) :
- au chargement initial → rien à trouver ;
- après interaction → le script vient de `load.sst.odysway.com`, jamais de `googletagmanager.com`, donc non reconnu ;
- `window.gtag` reste `undefined`, ce que beaucoup d'outils testent directement.

Le tracking fonctionnait bel et bien *après* interaction (vérifié en prod : `GTM-NP63ZR5`, `G-5XSC3EH8L6` et `AW-776808573` chargés, hits partant vers `region1.analytics.google.com` et `google.com/ccm/collect`). Le problème est donc double : tracking indétectable, et perte réelle de données pour tout visiteur rebondissant en moins de 15 s sans interagir.

## Changements

**`app/app.vue`** — GTM/SST se charge dès `onMounted`, sans condition.
- Suppression des 4 listeners d'interaction et du `setTimeout(15000)`.
- Suppression du cas particulier `/checkout` + `/confirmation` et de son `watch` sur la route, devenus inutiles puisque tout le monde charge immédiatement.
- Conservés : le gate `environment !== 'production'` et le garde-fou `window.google_tag_manager` (protection double-mount).

**`nuxt.config.ts`** — `dns-prefetch` → `preconnect` sur `load.sst.odysway.com`. Le commentaire existant justifiait le `dns-prefetch` par « on n'ouvre pas de connexion TLS avant l'interaction » ; ce n'est plus vrai.

## Compromis assumé

C'est un retour en arrière volontaire sur l'optimisation Lighthouse de mai/juillet. Les ~440 KB et ~2,9 s d'éval de GTM rentrent à nouveau dans la fenêtre de mesure, donc le score de perf synthétique va baisser. La détection des tags et la mesure des sessions courtes ont été jugées prioritaires.

## Vérification

Le dev server ne démarre pas dans ce repo (`Cannot find module 'sanity'` — le package Studio n'est ni dans `package.json` ni dans le lockfile). **Blocage pré-existant, sans rapport avec ce changement**, mais qui empêche toute vérification runtime locale. Vérifications statiques effectuées à la place :

- `npx eslint app/app.vue` → propre
- compilation `@vue/compiler-sfc` (`parse` + `compileScript` + `compileTemplate`) → OK ; `route` reste utilisé ailleurs (les UTM), aucune variable orpheline
- `nuxt.config.ts` évalué : les deux entrées `link` sortent correctement
- lint `nuxt.config.ts` : la seule erreur (`nuxt-config-keys-order`, ligne 6) est identique avant/après, confirmé via `git stash`

**Pas de preuve runtime.** À confirmer sur la preview Vercel : Tag Assistant doit voir `GTM-NP63ZR5` dès le chargement, sans interaction.

## Hors périmètre

Le CSP report-only (`server/middleware/csp-report-only.ts`) est incomplet et n'a pas été touché ici. Zéro impact aujourd'hui puisqu'il ne bloque rien, mais il casserait tout le tracking le jour où il passe en mode enforcé. Domaines manquants relevés dans les violations réelles en prod :

| Directive | À ajouter |
|---|---|
| `script-src` | `https://www.gstatic.com`, `https://googleads.g.doubleclick.net`, `https://www.googleadservices.com` |
| `connect-src` | `https://www.googletagmanager.com`, `https://*.google-analytics.com` (le `region1.`), `https://www.google.com`, `https://www.google.fr`, `https://*.doubleclick.net`, `https://www.googleadservices.com` |
| `img-src` | `https://*.doubleclick.net`, `https://www.google.com`, `https://www.google.fr`, `https://sst.odysway.com`, `https://www.facebook.com` |
| `frame-src` | `https://sst.odysway.com` |

À noter aussi : le pixel Facebook (`facebook.com/tr`) n'est whitelisté nulle part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)