### PR TITLE
feat(csp): collecter les violations et compléter l'allowlist

### DIFF
--- a/server/api/v1/csp-report.post.ts
+++ b/server/api/v1/csp-report.post.ts
@@ -1,0 +1,189 @@
+import supabase from '../../utils/supabase'
+
+// Sink des rapports de violation CSP émis par les navigateurs.
+//
+// Cet endpoint est public et non authentifié — il le doit : c'est le navigateur
+// du visiteur qui poste, sans cookie ni credential. Il est donc spammable par
+// n'importe qui, d'où les garde-fous ci-dessous (taille, forme, filtrage du
+// bruit, déduplication). Comme le sink funnel-error, il ne doit JAMAIS throw :
+// un rapport perdu est sans conséquence, une 500 en boucle sur chaque page vue
+// n'en est pas une.
+
+// Deux formats coexistent selon le mécanisme déclaré dans le header :
+//   - report-uri (historique)  -> application/csp-report, { "csp-report": {...} }
+//     clés en kebab-case : 'effective-directive', 'blocked-uri', 'document-uri'
+//   - report-to (Reporting API) -> application/reports+json, [ { type, body } ]
+//     clés en camelCase : effectiveDirective, blockedURL, documentURL
+// On déclare les deux (voir server/middleware/csp-report-only.ts), donc on doit
+// savoir lire les deux.
+interface RawReport {
+  'effective-directive'?: string
+  'violated-directive'?: string
+  'blocked-uri'?: string
+  'document-uri'?: string
+  'disposition'?: string
+  'effectiveDirective'?: string
+  'blockedURL'?: string
+  'documentURL'?: string
+}
+
+// Les extensions de navigateur déclenchent des violations en permanence en
+// injectant leurs propres scripts dans la page. Ce n'est pas notre code et on
+// n'y peut rien : sans ce filtre, elles représentent l'essentiel du volume et
+// noient les vraies violations. Même logique pour 'about:'/'null' que certains
+// navigateurs renvoient quand ils masquent l'URL bloquée cross-origin.
+const NOISE_PREFIXES = [
+  'chrome-extension:',
+  'moz-extension:',
+  'safari-extension:',
+  'safari-web-extension:',
+  'webkit-masked-url:',
+  'about:',
+]
+
+// Valeurs non-URL que la spec autorise pour blocked-uri. On les garde (savoir
+// qu'on viole 'inline' est utile) mais elles ne passent pas par new URL().
+const KEYWORD_URIS = ['inline', 'eval', 'data', 'blob', 'wasm-eval', 'self']
+
+const MAX_FIELD_LENGTH = 500
+
+// Déduplication en mémoire. Une page vue génère ~10 violations, chacune postée
+// par le navigateur : sans ça on écrirait des milliers de fois par jour la même
+// ligne. Le cache est par instance serverless et meurt avec elle — c'est
+// volontairement approximatif, d'où le nom `report_count` documenté comme une
+// borne inférieure côté migration.
+const recentlyWritten = new Map<string, number>()
+const DEDUP_WINDOW_MS = 5 * 60 * 1000
+
+const shouldWrite = (key: string): boolean => {
+  const now = Date.now()
+
+  // Purge opportuniste — pas de timer, on nettoie quand on passe.
+  if (recentlyWritten.size > 500) {
+    for (const [k, seenAt] of recentlyWritten) {
+      if (now - seenAt > DEDUP_WINDOW_MS) recentlyWritten.delete(k)
+    }
+  }
+
+  const seenAt = recentlyWritten.get(key)
+  if (seenAt && now - seenAt < DEDUP_WINDOW_MS) return false
+
+  recentlyWritten.set(key, now)
+  return true
+}
+
+const truncate = (value: unknown): string | null => {
+  if (typeof value !== 'string' || !value) return null
+  return value.slice(0, MAX_FIELD_LENGTH)
+}
+
+// On agrège sur l'origine, pas sur l'URL complète : les URLs de pixels Google
+// portent une trentaine de paramètres uniques par appel, donc agréger dessus
+// reviendrait à ne pas agréger du tout.
+const toOrigin = (blockedUri: string): string | null => {
+  if (KEYWORD_URIS.includes(blockedUri)) return blockedUri
+  try {
+    return new URL(blockedUri).origin
+  }
+  catch {
+    return null
+  }
+}
+
+// Les previews Vercel servent le même middleware CSP, donc leurs rapports sont
+// tout aussi valables — d'où le suffixe .vercel.app en plus des domaines de prod.
+const isOurDocument = (documentUri: unknown): boolean => {
+  if (typeof documentUri !== 'string' || !documentUri) return false
+  try {
+    const { hostname } = new URL(documentUri)
+    return hostname === 'odysway.com'
+      || hostname.endsWith('.odysway.com')
+      || hostname.endsWith('.vercel.app')
+      || hostname === 'localhost'
+  }
+  catch {
+    return false
+  }
+}
+
+// Extrait les deux formats vers une forme unique. Retourne null si le rapport
+// est inexploitable ou relève du bruit à ignorer.
+const normalize = (raw: RawReport) => {
+  const directive = raw['effective-directive']
+    || raw.effectiveDirective
+    || raw['violated-directive']
+
+  const blockedUri = raw['blocked-uri'] || raw.blockedURL
+  const documentUri = raw['document-uri'] || raw.documentURL
+
+  if (typeof directive !== 'string' || !directive) return null
+  if (typeof blockedUri !== 'string' || !blockedUri) return null
+  if (NOISE_PREFIXES.some(prefix => blockedUri.startsWith(prefix))) return null
+
+  // L'endpoint est public : sans ce filtre, n'importe qui peut remplir la table
+  // en postant des rapports fabriqués. Un rapport légitime décrit forcément une
+  // violation survenue sur une de nos pages, et document-uri est un champ requis
+  // par la spec — on peut donc l'exiger sans perdre de vrais rapports.
+  if (!isOurDocument(documentUri)) return null
+
+  const origin = toOrigin(blockedUri)
+  if (!origin) return null
+
+  return {
+    // La directive peut contenir la valeur complète en plus du nom dans le
+    // format historique ('script-src https://…') — on ne garde que le nom.
+    directive: directive.split(' ')[0].slice(0, 100),
+    origin: origin.slice(0, MAX_FIELD_LENGTH),
+    blockedUri: truncate(blockedUri),
+    documentUri: truncate(documentUri),
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  // Toujours 204 : la spec ne demande aucun corps de réponse, et on ne veut
+  // rien apprendre à un client qui sonderait l'endpoint.
+  setResponseStatus(event, 204)
+
+  try {
+    const body = await readBody(event)
+    if (!body) return null
+
+    // report-to envoie un tableau, report-uri un objet unique.
+    const reports = Array.isArray(body)
+      ? body.filter(entry => entry?.type === 'csp-violation').map(entry => entry?.body)
+      : [body['csp-report']]
+
+    for (const raw of reports.slice(0, 20)) {
+      if (!raw || typeof raw !== 'object') continue
+
+      const normalized = normalize(raw as RawReport)
+      if (!normalized) continue
+
+      const key = `${normalized.directive}|${normalized.origin}`
+      if (!shouldWrite(key)) continue
+
+      const { error } = await supabase.rpc('record_csp_violation', {
+        p_directive: normalized.directive,
+        p_origin: normalized.origin,
+        p_blocked_uri: normalized.blockedUri,
+        p_document_uri: normalized.documentUri,
+        // Renseigné par le navigateur : 'report' en Report-Only, 'enforce'
+        // après bascule. Absent des vieux rapports, d'où le défaut.
+        p_disposition: truncate((raw as RawReport).disposition) || 'report',
+      })
+
+      if (error) {
+        // On relâche la clé de dédup : sinon un incident Supabase de 5 minutes
+        // ferait silencieusement disparaître la violation de la collecte.
+        recentlyWritten.delete(key)
+        console.warn('[csp-report] écriture Supabase échouée:', error.message)
+      }
+    }
+
+    return null
+  }
+  catch (err) {
+    console.warn('[csp-report] rapport ignoré:', (err as Error)?.message || err)
+    return null
+  }
+})

--- a/server/middleware/csp-report-only.ts
+++ b/server/middleware/csp-report-only.ts
@@ -1,27 +1,109 @@
 // Content-Security-Policy in Report-Only mode.
 //
 // Report-Only NEVER blocks anything — the browser only logs violations to the
-// console (and to report-uri if configured). This lets us observe what the CSP
-// would break in production before switching to an enforcing policy in
+// console AND posts them to the report endpoint below. This lets us observe what
+// the CSP would break in production before switching to an enforcing policy in
 // nuxt.config.ts (security.headers.contentSecurityPolicy).
 //
-// Once the console is clean in production, move these directives into
-// nuxt-security's contentSecurityPolicy and drop this middleware.
+// The allowlist below was built from violations actually observed in production
+// (homepage, voyage page, /rdv-projet-voyage). It is NOT exhaustive: the funnel,
+// booking-management and non-French visitors were never exercised. Do not flip
+// this to enforcing until public.csp_violations has gone quiet on real traffic
+// for a few days — that table is the whole point of the report endpoint.
+
+// Google Ads fires its remarketing pixels at the visitor's country TLD
+// (google.fr here, google.be for a Belgian visitor, and so on). CSP cannot
+// wildcard a TLD, so this list is a deliberate choice: .com and .fr cover the
+// overwhelming majority of a French agency's traffic. Visitors elsewhere lose
+// the Ads remarketing pixel only — GA4 and conversion tracking are unaffected.
+const GOOGLE_TLDS = ['https://www.google.com', 'https://www.google.fr']
 
 const CSP_DIRECTIVES = [
   'default-src \'self\'',
+
   // GTM/SST, Stripe.js and Hotjar inject inline + external scripts; Vuetify/Nuxt need inline.
-  'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.googletagmanager.com https://load.sst.odysway.com https://sst.odysway.com https://js.stripe.com https://*.hotjar.com',
+  // gstatic/googleads/googleadservices are pulled in by the Ads tag at runtime,
+  // not by us. cal.com (/rdv-projet-voyage), tally.so (funnel) and capcadeau
+  // (gift cards) are embed widgets — see useCalEmbed.js, Funnel/TallyForm.vue,
+  // content/IntegrationCapcadeau.vue.
+  [
+    'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\'',
+    'https://www.googletagmanager.com',
+    'https://load.sst.odysway.com https://sst.odysway.com',
+    'https://www.gstatic.com',
+    'https://googleads.g.doubleclick.net',
+    'https://www.googleadservices.com',
+    'https://js.stripe.com',
+    'https://*.hotjar.com',
+    'https://app.cal.com',
+    'https://tally.so',
+    'https://www.capcadeau.com',
+  ].join(' '),
+
   'style-src \'self\' \'unsafe-inline\'',
-  'img-src \'self\' data: blob: https://cdn.sanity.io https://*.sanity.io https://www.googletagmanager.com https://*.google-analytics.com https://*.hotjar.com',
+
+  // GA4 and Ads deliver most of their payload as 1x1 pixels, hence the breadth
+  // here. sst.odysway.com serves a cookie-setting pixel (/_/set_cookie).
+  [
+    'img-src \'self\' data: blob:',
+    'https://cdn.sanity.io https://*.sanity.io',
+    'https://www.googletagmanager.com',
+    // Covers www.google-analytics.com AND region1.analytics.google.com, which
+    // is where GA4 actually sends EU traffic — the old www-only entry missed it.
+    'https://*.google-analytics.com https://*.analytics.google.com',
+    'https://*.doubleclick.net',
+    ...GOOGLE_TLDS,
+    'https://sst.odysway.com',
+    'https://www.facebook.com',
+    'https://*.hotjar.com',
+    'https://app.cal.com',
+  ].join(' '),
+
   'font-src \'self\' data: https://*.hotjar.com',
-  'connect-src \'self\' https://*.sanity.io https://*.algolia.net https://*.algolianet.com https://www.google-analytics.com https://load.sst.odysway.com https://sst.odysway.com https://*.hotjar.com wss://*.hotjar.com',
-  'frame-src \'self\' https://js.stripe.com https://hooks.stripe.com https://www.googletagmanager.com',
+
+  [
+    'connect-src \'self\'',
+    'https://*.sanity.io',
+    'https://*.algolia.net https://*.algolianet.com',
+    'https://www.googletagmanager.com',
+    'https://*.google-analytics.com https://*.analytics.google.com',
+    'https://*.doubleclick.net',
+    ...GOOGLE_TLDS,
+    'https://www.googleadservices.com',
+    'https://load.sst.odysway.com https://sst.odysway.com',
+    'https://*.hotjar.com wss://*.hotjar.com',
+    'https://app.cal.com',
+    'https://tally.so',
+  ].join(' '),
+
+  // sst.odysway.com frames itself for server-side tagging; the rest are embeds.
+  [
+    'frame-src \'self\'',
+    'https://js.stripe.com https://hooks.stripe.com',
+    'https://www.googletagmanager.com',
+    'https://sst.odysway.com',
+    'https://app.cal.com',
+    'https://tally.so',
+    'https://www.capcadeau.com',
+  ].join(' '),
+
   'frame-ancestors \'self\'',
   'base-uri \'self\'',
   'form-action \'self\'',
+
+  // Two reporting mechanisms on purpose. report-uri is deprecated but is what
+  // Safari and older Chrome still speak; report-to is the Reporting API and is
+  // what current Chrome prefers. They deliver different payload shapes — the
+  // endpoint reads both.
+  'report-uri /api/v1/csp-report',
+  'report-to csp-endpoint',
 ].join('; ')
+
+// report-to references a group declared in this separate header; without it
+// Chrome silently ignores the directive.
+const REPORTING_ENDPOINTS = 'csp-endpoint="/api/v1/csp-report"'
 
 export default defineEventHandler((event) => {
   setResponseHeader(event, 'Content-Security-Policy-Report-Only', CSP_DIRECTIVES)
+  setResponseHeader(event, 'Reporting-Endpoints', REPORTING_ENDPOINTS)
 })

--- a/supabase/migrations/20260812120000_csp_violations.sql
+++ b/supabase/migrations/20260812120000_csp_violations.sql
@@ -1,0 +1,126 @@
+-- =========================================================================
+-- Collecte des violations CSP
+-- =========================================================================
+-- Le CSP est servi en Report-Only depuis le 16/07/2026 (server/middleware/
+-- csp-report-only.ts) avec l'intention de passer en mode bloquant "une fois la
+-- console propre en production". Sans endpoint de collecte, cette vérification
+-- reposait sur un développeur qui pense à ouvrir la console, sur les pages
+-- qu'il pense à visiter — donc elle n'a jamais eu lieu.
+--
+-- Cette table agrège les rapports envoyés par les navigateurs. On ne stocke PAS
+-- un rapport par violation : le volume serait de l'ordre de 10 lignes par page
+-- vue. On agrège sur le couple (directive, origine bloquée), qui est exactement
+-- la granularité à laquelle on écrit une règle CSP.
+
+CREATE TABLE IF NOT EXISTS public.csp_violations (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- La directive effectivement violée ('script-src-elem', 'connect-src'…).
+    -- Attention : ce n'est pas toujours la directive écrite dans la policy —
+    -- 'script-src-elem' n'est pas déclarée chez nous et retombe sur 'script-src'.
+    effective_directive text        NOT NULL,
+
+    -- Origine de la ressource bloquée, normalisée ('https://www.gstatic.com').
+    -- Les valeurs non-URL renvoyées par les navigateurs ('inline', 'eval',
+    -- 'data', 'blob') sont conservées telles quelles.
+    blocked_origin      text        NOT NULL,
+
+    -- Un exemple complet, pour pouvoir enquêter. Écrasé à chaque écriture :
+    -- c'est un échantillon, pas un historique.
+    sample_blocked_uri  text,
+    sample_document_uri text,
+
+    -- 'report' tant qu'on est en Report-Only, 'enforce' après bascule. Permet de
+    -- distinguer les violations observées des violations réellement bloquées.
+    disposition         text,
+
+    -- Nombre d'ÉCRITURES, pas de violations. L'endpoint déduplique en mémoire
+    -- par instance serverless (voir server/api/v1/csp-report.post.ts), donc
+    -- c'est une borne inférieure très grossière. À lire comme un signal de
+    -- fréquence relative, jamais comme une métrique.
+    report_count        bigint      NOT NULL DEFAULT 1,
+
+    first_seen_at       timestamptz NOT NULL DEFAULT now(),
+    last_seen_at        timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT csp_violations_unique_pair UNIQUE (effective_directive, blocked_origin)
+);
+
+COMMENT ON TABLE public.csp_violations IS
+    'Violations CSP agrégées par (directive, origine bloquée). Alimentée par POST /api/v1/csp-report.';
+COMMENT ON COLUMN public.csp_violations.report_count IS
+    'Nombre d''écritures, pas de violations : l''endpoint déduplique en mémoire. Signal relatif uniquement.';
+
+-- Le tri naturel de lecture : "qu'est-ce qui casse encore, le plus récemment ?"
+CREATE INDEX IF NOT EXISTS csp_violations_last_seen_idx
+    ON public.csp_violations (last_seen_at DESC);
+
+-- =========================================================================
+-- Upsert atomique
+-- =========================================================================
+-- L'incrément d'un compteur ne s'exprime pas avec un upsert PostgREST, et deux
+-- rapports concurrents sur la même paire doivent fusionner sans perdre l'un des
+-- deux. D'où une fonction plutôt qu'un .upsert() côté client.
+CREATE OR REPLACE FUNCTION public.record_csp_violation(
+    p_directive    text,
+    p_origin       text,
+    p_blocked_uri  text,
+    p_document_uri text,
+    p_disposition  text
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    INSERT INTO public.csp_violations AS v (
+        effective_directive, blocked_origin,
+        sample_blocked_uri, sample_document_uri, disposition
+    )
+    VALUES (p_directive, p_origin, p_blocked_uri, p_document_uri, p_disposition)
+    ON CONFLICT ON CONSTRAINT csp_violations_unique_pair DO UPDATE
+    SET report_count        = v.report_count + 1,
+        last_seen_at        = now(),
+        sample_blocked_uri  = COALESCE(EXCLUDED.sample_blocked_uri, v.sample_blocked_uri),
+        sample_document_uri = COALESCE(EXCLUDED.sample_document_uri, v.sample_document_uri),
+        disposition         = COALESCE(EXCLUDED.disposition, v.disposition);
+$$;
+
+-- PostgREST expose toute fonction publique en RPC, et PostgreSQL accorde EXECUTE
+-- à PUBLIC par défaut. Sans cette révocation, n'importe qui muni de la clé anon
+-- (qui est publique, elle est dans le bundle client) pourrait appeler
+-- /rest/v1/rpc/record_csp_violation et remplir la table de n'importe quoi.
+-- Seul le serveur, qui utilise la service_role key, doit pouvoir écrire.
+REVOKE EXECUTE ON FUNCTION public.record_csp_violation(text, text, text, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.record_csp_violation(text, text, text, text, text) FROM anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.record_csp_violation(text, text, text, text, text) TO service_role;
+
+-- =========================================================================
+-- RLS
+-- =========================================================================
+-- L'endpoint passe par la service_role key (server/utils/supabase.js), qui
+-- contourne RLS. On active RLS sans aucune policy : la table devient donc
+-- inaccessible à anon/authenticated, et seul le serveur écrit dedans.
+ALTER TABLE public.csp_violations ENABLE ROW LEVEL SECURITY;
+
+-- Volontairement plus strict que les migrations plus anciennes (ac_processed_events
+-- et consorts), qui font GRANT ALL à anon et authenticated en comptant sur RLS
+-- seule. Ici on retire aussi les privilèges de table : Supabase pose des default
+-- privileges sur le schéma public, donc sans ce REVOKE la table serait accordée à
+-- anon à sa création. RLS suffirait, mais deux verrous valent mieux qu'un sur une
+-- table alimentée par un endpoint public.
+REVOKE ALL ON TABLE public.csp_violations FROM anon, authenticated;
+GRANT  ALL ON TABLE public.csp_violations TO service_role;
+
+-- =========================================================================
+-- Vérification
+-- =========================================================================
+DO $$
+DECLARE has_fn boolean;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public' AND p.proname = 'record_csp_violation'
+    ) INTO has_fn;
+    RAISE NOTICE 'csp_violations : table créée, fonction record_csp_violation présente = %', has_fn;
+END $$;


### PR DESCRIPTION
Fait suite à #255. Le CSP reste en **Report-Only** : cette PR ne bloque rien.

## Le problème

Le middleware `csp-report-only.ts` annonce depuis le 16/07 : *« Once the console is clean in production, move these directives into nuxt-security's contentSecurityPolicy »*.

Sauf qu'il n'y avait **ni `report-uri` ni `report-to`**. Cette vérification reposait donc sur un développeur qui pense à ouvrir la console, sur les pages qu'il pense à visiter. Elle n'a jamais eu lieu, et la policy n'a pas bougé depuis. En naviguant sur trois pages j'ai trouvé une nouvelle violation à chaque changement de page — compléter la liste à la main, c'est jouer au chat et à la souris.

## Collecte

**`supabase/migrations/20260812120000_csp_violations.sql`** — table agrégée sur le couple `(directive, origine bloquée)`, soit exactement la granularité à laquelle on écrit une règle CSP. On ne stocke pas un rapport par violation : le volume serait d'environ 10 lignes par page vue. L'incrément passe par une fonction `record_csp_violation` plutôt qu'un upsert PostgREST, pour que deux rapports concurrents fusionnent sans en perdre un.

**`server/api/v1/csp-report.post.ts`** — lit les **deux** formats que les navigateurs émettent, ce qui n'est pas interchangeable :

| Mécanisme | Content-Type | Forme | Clés |
|---|---|---|---|
| `report-uri` | `application/csp-report` | objet `{"csp-report": {…}}` | kebab-case (`blocked-uri`) |
| `report-to` | `application/reports+json` | tableau `[{type, body}]` | camelCase (`blockedURL`) |

On déclare les deux (Safari et Chrome ancien ne parlent que le premier), donc l'endpoint doit savoir lire les deux.

Il agrège sur l'origine — les URLs de pixels Google portent une trentaine de paramètres uniques par appel, agréger dessus reviendrait à ne pas agréger — filtre le bruit des extensions de navigateur, qui représenteraient sinon l'essentiel du volume, et déduplique en mémoire sur 5 minutes.

### Surface d'attaque

L'endpoint est public et non authentifié, et il le doit : c'est le navigateur du visiteur qui poste, sans cookie ni credential. Deux garde-fous en conséquence :

- **Rapports fabriqués** — un rapport dont le `document-uri` n'est pas un de nos domaines est rejeté. Le champ est requis par la spec, donc on peut l'exiger sans perdre de vrais rapports.
- **Appel direct via PostgREST** — `record_csp_violation` est révoquée pour `anon` et `authenticated`. Sans ça, la clé anon (qui est publique, elle est dans le bundle client) permettait d'appeler `/rest/v1/rpc/record_csp_violation` et de remplir la table. La table elle-même est en RLS sans policy **et** avec les privilèges retirés à `anon` — volontairement plus strict que les migrations plus anciennes, qui font `GRANT ALL` à `anon` en comptant sur RLS seule.

## Allowlist

Complétée à partir des violations **réellement observées en production** (accueil, `/voyages/perou-immersion-communaute-quechua`, `/rdv-projet-voyage`), relevées via l'événement `securitypolicyviolation` :

| Directive | Ajouts | Origine |
|---|---|---|
| `script-src` | `www.gstatic.com`, `googleads.g.doubleclick.net`, `www.googleadservices.com` | tag Google Ads |
| | `app.cal.com`, `tally.so`, `www.capcadeau.com` | embeds : `useCalEmbed.js`, `Funnel/TallyForm.vue`, `IntegrationCapcadeau.vue` |
| `connect-src` | `www.googletagmanager.com`, `*.analytics.google.com`, `*.doubleclick.net`, `www.googleadservices.com`, google.com/.fr, cal.com, tally.so | GA4 + Ads + embeds |
| `img-src` | `*.doubleclick.net`, `*.analytics.google.com`, google.com/.fr, `sst.odysway.com`, `www.facebook.com`, cal.com | pixels |
| `frame-src` | `sst.odysway.com`, `app.cal.com`, `tally.so`, `www.capcadeau.com` | sGTM + embeds |

Deux pièges qui méritent l'attention du reviewer :

1. **`www.google-analytics.com` ne suffisait pas.** GA4 envoie le trafic européen sur `region1.analytics.google.com` — un autre domaine, que l'entrée `www`-only ne couvrait pas. D'où `*.analytics.google.com`.
2. **Google Ads tape sur le TLD pays du visiteur** (`google.fr` ici, `google.be` pour un Belge…). Le CSP ne sait pas wildcarder un TLD. Choix assumé : `.com` et `.fr` seulement. Les visiteurs d'autres pays perdront le pixel de remarketing Ads une fois le CSP en mode bloquant — GA4 et le suivi de conversion ne sont pas affectés.

Rien à ajouter pour Stripe ni Alma : le checkout redirige côté serveur, aucun SDK n'est chargé dans `app/`. Supabase n'est pas non plus appelé côté client.

## Vérification

Le dev server ne démarre pas dans ce repo (`Cannot find module 'sanity'`, blocage pré-existant), et ni `psql` ni Docker ne sont disponibles. **La migration SQL n'a donc pas été exécutée** — c'est le principal angle mort de cette PR, à relire attentivement. Le reste a été vérifié en exerçant le vrai code :

**Policy** — le middleware est chargé, le header capturé et parsé, puis chaque violation observée en prod est testée contre lui (avec le repli `script-src-elem` → `script-src` et le matching de wildcard conforme à la spec) : 15/15 passent, plus 9 cas de non-régression sur ce qui marchait déjà.

**Endpoint** — le vrai handler est exercé avec `fetch` intercepté pour capturer ce qui partirait vers Supabase, sur 23 cas : les deux formats de rapport, l'agrégation sur l'origine, le filtrage des extensions, le rejet des rapports fabriqués (dont `odysway.com.attaquant.net`), la déduplication, le plafond de 20 rapports par requête et la troncature à 500 caractères.

ESLint propre sur les fichiers touchés. À noter : `CLAUDE.md` annonce « no trailing commas » mais la config ESLint impose l'inverse — j'ai suivi la config.

## Suite

Cette PR ne fait que collecter. Le passage en mode bloquant — et la migration vers `security.headers.contentSecurityPolicy` de nuxt-security — fera l'objet d'une PR séparée, une fois que `csp_violations` sera silencieuse sur du vrai trafic. Le funnel, `/booking-management` et les visiteurs hors France n'ont jamais été exercés ici ; c'est précisément ce que la table doit révéler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)