### PR TITLE
fix(header): figer le poids des boutons de la topbar en medium

### DIFF
--- a/app/components/HeaderOdysway.vue
+++ b/app/components/HeaderOdysway.vue
@@ -80,7 +80,7 @@
           v-if="header?.button2?.visible"
           height="45"
           color="primary"
-          class="text-caption text-md-body-1"
+          class="text-caption text-md-body-1 font-weight-medium"
           :class="isTransparent ? 'filter' : ''"
           @click="handleButton2Click"
         >
@@ -90,7 +90,7 @@
           v-if="header?.button3?.visible"
           height="45"
           color="primary"
-          class="text-caption text-md-body-1"
+          class="text-caption text-md-body-1 font-weight-medium"
           :class="isTransparent ? 'filter' : ''"
           @click="handleButton3Click"
         >
@@ -108,7 +108,7 @@
           height="45"
           color="primary"
           rounded="default"
-          class="text-caption text-md-body-1 d-none d-md-inline"
+          class="text-caption text-md-body-1 font-weight-medium d-none d-md-inline"
           :class="isTransparent ? 'filter' : ''"
           @click="handleButton1Click"
         >
@@ -130,7 +130,7 @@
             rounded="pill"
             :variant="isTransparent ? 'text' : 'outlined'"
             :class="isTransparent ? 'filter' : ''"
-            class="text-caption text-md-body-1 d-none d-md-flex"
+            class="text-caption text-md-body-1 font-weight-medium d-none d-md-flex"
             @click="handleButton4Click"
           >
             <span class="align-center">{{ header.button4.text }}</span>
@@ -141,7 +141,7 @@
             rounded="pill"
             :variant="isTransparent ? 'text' : 'tonal'"
             :class="isTransparent ? 'text-soft-blush text-shadow' : 'bg-primary text-white '"
-            class="text-caption text-md-body-1 d-none d-md-inline "
+            class="text-caption text-md-body-1 font-weight-medium d-none d-md-inline "
             @click="handleButton5Click"
           >
             {{ header.button5.text }}


### PR DESCRIPTION
## Problème

En production, seul le bouton **Destinations** de la topbar s'affiche en gras ; les autres (« Prochains départs », « L'esprit Odysway », téléphone, « Prendre RDV ») sont visiblement plus fins. En local, tous les boutons ont le même poids. Le code est pourtant strictement identique — c'est un problème de cascade CSS, pas de code.

## Cause

Les boutons du header portent `text-md-body-1`. Dans Vuetify, `font-weight` fait partie des propriétés `unimportant` de l'utilitaire typography (`styles/settings/_utilities.scss`) : `font-size` sort en `!important`, mais `font-weight: 400` **non**.

Cette déclaration entre donc en égalité de spécificité (0,1,0) avec `.v-btn { font-weight: 500 }` de `VBtn.css`, et **c'est l'ordre source qui tranche** — un ordre qui diffère entre les deux environnements :

| | Ordre de chargement | Gagnant |
|---|---|---|
| **dev** | `vite-plugin-vuetify` injecte le CSS de `VBtn` au runtime, *après* `main.scss` | `.v-btn` → **500** |
| **prod** | `vendor-vuetify.css` est chargé *avant* `entry.css` | `.text-md-body-1` → **400** |

Seul « Destinations » y échappait : son `font-weight: 500` déclaré dans le `<style scoped>` de `DestinationsMegaMenu.vue` monte à (0,2,0) grâce à l'attribut `[data-v-*]` et gagne quel que soit l'ordre.

À noter : l'écart n'est visible qu'au-dessus de 960px. En dessous c'est `text-caption` qui s'applique, et le caption est configuré en `weight: 500` dans le `$typography` du projet — donc uniforme partout.

## Correctif

Ajout de `font-weight-medium` sur les cinq `v-btn` du header. Cet utilitaire Vuetify, lui, sort bien en `!important`, ce qui rend le rendu déterministe et indépendant de l'ordre de bundling. Le rendu retenu est celui du local (medium partout).

## Vérification

Le dev server ne boote pas dans ce worktree (`Cannot find module 'sanity'` — problème connu du repo, sans rapport avec ce changement). La classe a donc été appliquée directement sur odysway.com, qui sert le CSS de production, pour mesurer l'effet réel :

| Bouton | Avant (prod) | Après |
|---|---|---|
| Destinations | 500 | 500 |
| Prochains départs | **400** | **500** |
| L'esprit Odysway | **400** | **500** |
| +33 1 84 80 79 75 | 400 | 500 |
| Prendre RDV 👋 | 400 | 500 |

## Pour le reviewer

Ce bug de cascade n'est **pas propre au header** : partout où un `v-btn` porte `text-body-1` / `text-body-2` (ou leurs variantes responsive), le poids bascule de 500 en dev à 400 en prod. Cette PR ne corrige que la topbar. Un correctif global — une règle unique dans `main.scss` après l'import Vuetify — reste possible si l'équipe préfère traiter le problème à la racine plutôt que composant par composant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)