### PR TITLE
feat(bms): refonte visuelle du backoffice + poste de pilotage des départs

### DIFF
--- a/app/assets/scss/backoffice.scss
+++ b/app/assets/scss/backoffice.scss
@@ -5,61 +5,93 @@
 // partir dans le bundle du site public. Les visiteurs de odysway.com n'ont
 // aucune raison de télécharger le CSS d'un outil interne.
 //
-// Tout dérive du teal de marque (#2B4C52) : les neutres sont teintés teal
-// (jamais de gris neutre), il n'y a qu'un seul accent, et les couleurs
-// sémantiques sont désaturées au même niveau de chroma que l'accent pour qu'un
-// état se lise sans crier.
+// Palette et formes reprises de la maquette « Poste de pilotage · GIR Engine »
+// (12 août 2026) : neutres froids, accent indigo, surfaces blanches légèrement
+// ombrées, rayons généreux, pastilles arrondies.
 //
-// Règle de couleur, valable partout dans le backoffice :
-//   - l'accent ne signifie rien  -> c'est l'action
-//   - les sémantiques ne décorent rien -> c'est l'état
+// Règles de couleur, valables partout dans le backoffice :
+//   - l'indigo ne signifie rien -> c'est l'action, et l'identité de l'outil
+//   - les sémantiques ne décorent rien -> c'est l'état, ou la catégorie
+//     opérationnelle d'un départ (vert à garantir / indigo à maximiser /
+//     bleu à décider / gris exhaustif)
+//   - le rouge est réservé aux vraies alertes : une échéance dépassée, une
+//     suppression, un blocage. Jamais « peu rempli », jamais « à surveiller ».
+//
+// Chaque famille sémantique existe en trois valeurs :
+//   --bo-x        aplat vif        -> barres, bandes, filets, points
+//   --bo-x-soft   fond de pastille -> jamais du texte
+//   --bo-x-ink    texte sur -soft  -> la seule valeur autorisée pour du texte
+// L'aplat vif ne passe pas 4,5:1 sur blanc : ne jamais l'utiliser comme
+// couleur de texte, prendre --bo-x-ink.
 // =============================================================================
 
 :root {
-  // --- neutres teintés teal ---
-  --bo-paper: #f1f4f4; // fond de page
+  // --- neutres froids ---
+  --bo-paper: #f5f6f8; // fond de page
   --bo-surface: #ffffff; // cartes, tables
-  --bo-surface-2: #f7f9f9; // lignes survolées, champs en lecture seule
-  --bo-line: #dde4e4; // filets 1px
-  --bo-line-soft: #e9eeee; // séparateurs internes
-  --bo-ink: #16262b; // texte principal
-  --bo-ink-2: #5b7075; // texte secondaire
-  --bo-ink-3: #8ca0a4; // libellés, texte tertiaire
+  --bo-surface-2: #fafbfc; // lignes survolées, en-têtes de table
+  --bo-line: #eceef2; // filets 1px
+  --bo-line-soft: #f0f2f5; // séparateurs internes
+  --bo-ink: #1b1d23; // texte principal
+  --bo-ink-2: #4b5563; // texte secondaire
+  --bo-ink-3: #6b7280; // libellés, texte tertiaire
 
   // --- surfaces de contrôle ---
-  // Règle unique, valable dans les deux thèmes : **un champ s'enfonce sous la
-  // surface qui le porte, un bouton ressort au-dessus**. C'est ce qui rend une
-  // zone de saisie identifiable sans avoir à lire son filet.
-  // (Le prototype peignait les champs en blanc ; sur une carte blanche ils ne
-  // se détachaient que par leur bordure — d'où ce gris.)
-  --bo-field: #eef2f2; // fond d'un champ de saisie
-  --bo-field-line: #dde4e4; // filet d'un champ / d'un bouton secondaire
+  // En clair la maquette pose champs et boutons secondaires sur du blanc : ils
+  // se lisent par leur filet et leur ombre, pas par un aplat gris. En sombre
+  // cette égalité ne tient pas — le thème sombre plus bas creuse le champ sous
+  // la carte et remonte le bouton au-dessus.
+  --bo-field: #ffffff; // fond d'un champ de saisie
+  --bo-field-line: #eceef2; // filet d'un champ / d'un bouton secondaire
   --bo-control: #ffffff; // fond d'un bouton secondaire, d'un segment
+  --bo-control-2: #e7e9ee; // bouton secondaire appuyé (« Appliquer »)
 
   // --- accent unique ---
-  --bo-accent: #2b4c52;
+  --bo-accent: #5b5bd6;
   --bo-accent-ink: #ffffff;
-  --bo-accent-wash: #2b4c520f;
+  --bo-accent-soft: #eeeefb; // fond de pastille indigo
+  --bo-accent-soft-ink: #4b3fc0; // texte sur --bo-accent-soft — 6,3:1
+  --bo-accent-line: #dcdcf7;
+  --bo-accent-wash: #5b5bd60f;
+  --bo-accent-grad: linear-gradient(120deg, #4b4bc8, #6d5be0);
 
-  // --- sémantiques (état, jamais décoratives) ---
-  // Saturées pour ressortir sur les surfaces neutres. Chaque valeur est la plus
-  // vive qui tienne encore 4,5:1 sur --bo-field (la plus sombre des surfaces
-  // claires) : le texte des tags fait 10px bold, il n'a pas de marge d'erreur.
-  --bo-ok: #0b7a4b; // confirmé, payé, publié          — 4,77:1
-  --bo-warn: #c2410c; // à surveiller, brouillon, acompte — 4,59:1
-  --bo-crit: #c0261f; // bloquant, supprimé, orphelin     — 5,26:1
-  --bo-info: #0b6bcb; // neutre qualifié (individuel, option) — 4,68:1
+  // --- sémantiques ---
+  --bo-ok: #12a150;
+  --bo-ok-soft: #e6f6ed;
+  --bo-ok-ink: #1b7a43; // 4,55:1 sur --bo-ok-soft
+
+  --bo-warn: #e5920a;
+  --bo-warn-soft: #fbf0dc;
+  --bo-warn-ink: #9a6300; // 4,84:1 sur --bo-warn-soft
+
+  --bo-crit: #e5484d;
+  --bo-crit-soft: #fbe7e8;
+  --bo-crit-ink: #b42318; // 5,52:1 sur --bo-crit-soft
+
+  --bo-info: #0e7fe1;
+  --bo-info-soft: #e3f0fc;
+  --bo-info-ink: #0a63b0; // 4,97:1 sur --bo-info-soft
+
+  // Départs garantis par un partenaire (co-remplissage) : ni un état sain ni
+  // une alerte — une catégorie à part, d'où sa propre teinte.
+  --bo-part: #7c3aed;
+  --bo-part-soft: #ede9fe;
+  --bo-part-ink: #6d28d9;
+
+  // Neutre qualifié : « non suivi », « sans traction ».
+  --bo-neutral-soft: #eef0f3;
 
   // --- rail de navigation (constant, indépendant du fond de page) ---
-  --bo-rail: #12222a;
-  --bo-rail-2: #1b2f38;
-  --bo-rail-ink: #a9bec2;
-  --bo-rail-ink-2: #6c868d;
-  --bo-rail-accent: #78adb3; // l'accent lisible sur fond sombre
+  --bo-rail: #0c1922;
+  --bo-rail-2: #16242e;
+  --bo-rail-ink: #aeb9c1;
+  --bo-rail-ink-2: #5c6b75;
+  --bo-rail-accent: #12a150; // le vert de marque, seul repère coloré du rail
 
   // --- formes ---
-  --bo-radius: 5px;
-  --bo-radius-s: 3px;
+  --bo-radius: 12px; // cartes, tables, panneaux
+  --bo-radius-s: 8px; // boutons, champs, chips
+  --bo-radius-pill: 999px; // pastilles d'état, onglets, filtres
 
   // --- typographie ---
   // L'interface reprend Gordita (déjà chargée) ; tout chiffre passe en
@@ -69,7 +101,8 @@
   // --- rythme ---
   --bo-gap: 20px; // entre sections
   --bo-gap-s: 12px; // dans une carte
-  --bo-shadow-pop: 0 8px 28px -12px #0b191e4d, 0 1px 2px #0b191e14;
+  --bo-shadow: 0 1px 2px #10182806, 0 4px 16px #1018280f;
+  --bo-shadow-pop: 0 8px 28px -12px #10182859, 0 1px 2px #10182814;
 }
 
 // =============================================================================
@@ -84,37 +117,66 @@
 // Ce n'est pas une inversion mécanique du thème clair : les sémantiques sont
 // ré-éclaircies pour rester lisibles sur fond sombre, et le rail garde sa
 // teinte pour rester le point d'ancrage constant de l'interface.
+//
+// La maquette ne couvre que le clair ; ce thème en est la dérivation. Deux
+// écarts assumés, notés sur place : les champs se creusent sous la carte
+// (règle inverse du clair), et les fonds de pastille -soft sont recalculés en
+// mélangeant 16 % de l'aplat vif dans la surface, l'aplat lui-même servant
+// alors de couleur de texte.
 // =============================================================================
 
 :root[data-bo-theme='dark'] {
-  --bo-paper: #0d171b;
-  --bo-surface: #142329;
-  --bo-surface-2: #1a2c33;
-  --bo-line: #24393f;
-  --bo-line-soft: #1d3037;
-  --bo-ink: #e2eaea;
-  --bo-ink-2: #94aaaf;
-  --bo-ink-3: #6b8288;
+  --bo-paper: #0f1116;
+  --bo-surface: #171a21;
+  --bo-surface-2: #1c2029;
+  --bo-line: #272c36;
+  --bo-line-soft: #21262f;
+  --bo-ink: #e7e9ef;
+  --bo-ink-2: #a8b0bf;
+  --bo-ink-3: #7c8494;
 
   // Le champ passe *sous* la carte (plus sombre qu'elle) et son filet gagne en
   // contraste : à surface égale, un champ était invisible sur une carte.
-  --bo-field: #0e1b20;
-  --bo-field-line: #324a51;
+  --bo-field: #10131a;
+  --bo-field-line: #333a47;
 
   // Le bouton secondaire passe *au-dessus* de la carte.
-  --bo-control: #1b2e35;
+  --bo-control: #1e222b;
+  --bo-control-2: #272c36;
 
-  --bo-accent: #78adb3;
-  --bo-accent-ink: #0d171b;
-  --bo-accent-wash: #78adb31a;
+  --bo-accent: #8b8be8;
+  --bo-accent-ink: #0f1116;
+  --bo-accent-soft: #2a2c41;
+  --bo-accent-soft-ink: #b9b9f5;
+  --bo-accent-line: #3a3d5c;
+  --bo-accent-wash: #8b8be81a;
+  --bo-accent-grad: linear-gradient(120deg, #3b3b9e, #5a4bb8);
 
-  // Mêmes teintes qu'en clair, remontées pour le fond sombre (toutes ≥ 5,8:1
-  // sur --bo-surface).
+  // Aplats remontés pour le fond sombre ; sur -soft ils tiennent tous ≥ 5,5:1,
+  // ce qui permet de les réutiliser tels quels comme couleur de texte.
   --bo-ok: #34d399;
-  --bo-warn: #ffa726;
-  --bo-crit: #f87171;
-  --bo-info: #60a5fa;
+  --bo-ok-soft: #1c3834;
+  --bo-ok-ink: #34d399;
 
+  --bo-warn: #fbbf24;
+  --bo-warn-soft: #3c3421;
+  --bo-warn-ink: #fbbf24;
+
+  --bo-crit: #f87171;
+  --bo-crit-soft: #3b282e;
+  --bo-crit-ink: #f87171;
+
+  --bo-info: #60a5fa;
+  --bo-info-soft: #233044;
+  --bo-info-ink: #60a5fa;
+
+  --bo-part: #a78bfa;
+  --bo-part-soft: #2e2c44;
+  --bo-part-ink: #a78bfa;
+
+  --bo-neutral-soft: #242932;
+
+  --bo-shadow: 0 1px 2px #00000059, 0 4px 16px #0000003d;
   --bo-shadow-pop: 0 8px 28px -12px #00000099, 0 1px 2px #0000004d;
 
   // Indispensable : sans ça les contrôles natifs (sélecteurs de date, listes
@@ -133,7 +195,7 @@
 .bo {
   background: var(--bo-paper);
   color: var(--bo-ink);
-  font-size: 13px;
+  font-size: 13.5px;
   line-height: 1.45;
 
   .v-main {
@@ -212,6 +274,10 @@
     padding: 14px 16px 16px;
   }
 
+  // Marque : contour vert plutôt qu'aplat indigo. Le rail est la seule zone de
+  // l'interface qui ne change pas d'un écran à l'autre ; son unique point
+  // coloré reste le vert Odysway, pour ne pas entrer en concurrence avec
+  // l'indigo qui, lui, désigne l'action dans la page.
   &__mark {
     width: 26px;
     height: 26px;
@@ -219,10 +285,10 @@
     display: grid;
     place-items: center;
     border-radius: var(--bo-radius-s);
-    background: var(--bo-accent);
-    color: #fff;
-    font-weight: 700;
-    font-size: 13px;
+    border: 2px solid var(--bo-rail-accent);
+    color: var(--bo-rail-accent);
+    font-weight: 800;
+    font-size: 12px;
   }
 
   &__name {
@@ -523,7 +589,11 @@
   background: var(--bo-surface) !important;
   border: 1px solid var(--bo-line) !important;
   border-radius: var(--bo-radius) !important;
-  box-shadow: none !important;
+
+  // La maquette pose une ombre très basse sur toutes les surfaces : c'est elle
+  // qui détache la carte du fond, le filet seul ne suffit plus à ce niveau de
+  // contraste (#FFF sur #F5F6F8).
+  box-shadow: var(--bo-shadow) !important;
 
   &__head {
     display: flex;
@@ -547,29 +617,37 @@
 }
 
 // =============================================================================
-// Tag d'état — carré, discret, jamais une pastille marketing
+// Pastille d'état
+//
+// Aplat doux + texte foncé de la même famille, sans filet : c'est la forme de
+// la maquette. Pas de capitales — à 10,5 px elles coûtent en lisibilité ce
+// qu'elles apportent en autorité, et la pastille n'a pas besoin de crier.
+//
+// Le fond vient de --bo-x-soft et le texte de --bo-x-ink : ce sont les seules
+// paires vérifiées en contraste. Ne jamais y mettre --bo-x tel quel.
 // =============================================================================
 
 .bo-tag {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 2.5px 6px;
-  border-radius: var(--bo-radius-s);
-  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: var(--bo-radius-pill);
+  font-size: 10.5px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0;
   white-space: nowrap;
-  color: var(--bo-ink-2);
-  background: color-mix(in srgb, currentcolor 9%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentcolor 22%, transparent);
+  color: var(--bo-ink-3);
+  background: var(--bo-neutral-soft);
 
-  &--ok { color: var(--bo-ok); }
-  &--warn { color: var(--bo-warn); }
-  &--crit { color: var(--bo-crit); }
-  &--info { color: var(--bo-info); }
-  &--accent { color: var(--bo-accent); }
+  &--ok { color: var(--bo-ok-ink); background: var(--bo-ok-soft); }
+  &--warn { color: var(--bo-warn-ink); background: var(--bo-warn-soft); }
+  &--crit { color: var(--bo-crit-ink); background: var(--bo-crit-soft); }
+  &--info { color: var(--bo-info-ink); background: var(--bo-info-soft); }
+  &--accent { color: var(--bo-accent-soft-ink); background: var(--bo-accent-soft); }
+
+  // Départ garanti par un partenaire : ni sain ni alerte, sa propre teinte.
+  &--part { color: var(--bo-part-ink); background: var(--bo-part-soft); }
 }
 
 .bo-dot {
@@ -645,22 +723,26 @@
 }
 
 // =============================================================================
-// Bandeau de statistiques — tuiles compactes, pas des cartes géantes
+// Bandeau de statistiques
+//
+// Tuiles autonomes espacées, pas une grille soudée : la maquette les traite en
+// cartes indépendantes qui se réorganisent seules (auto-fit). Le chiffre peut
+// porter la couleur de sa catégorie — c'est le seul endroit du backoffice où
+// une sémantique colore autre chose qu'un état.
 // =============================================================================
 
 .bo-stats {
   display: grid;
-  grid-template-columns: repeat(var(--bo-stats-cols, 4), 1fr);
-  gap: 1px;
-  background: var(--bo-line);
-  border: 1px solid var(--bo-line);
-  border-radius: var(--bo-radius);
-  overflow: hidden;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: var(--bo-gap-s);
 }
 
 .bo-stat {
   background: var(--bo-surface);
-  padding: 12px 14px;
+  border: 1px solid var(--bo-line);
+  border-radius: var(--bo-radius);
+  box-shadow: var(--bo-shadow);
+  padding: 13px 16px;
 
   &__k {
     font-size: 10.5px;
@@ -678,6 +760,7 @@
     font-weight: 600;
     letter-spacing: -0.02em;
     line-height: 1.15;
+    color: var(--bo-stat-c, inherit);
   }
 
   &__unit {
@@ -690,6 +773,14 @@
     font-size: 11px;
     color: var(--bo-ink-2);
   }
+
+  // Teinte de catégorie sur le chiffre. On prend la valeur -ink : le chiffre
+  // est du texte, il est posé sur la surface blanche, pas sur un aplat doux.
+  &--ok { --bo-stat-c: var(--bo-ok-ink); }
+  &--warn { --bo-stat-c: var(--bo-warn-ink); }
+  &--crit { --bo-stat-c: var(--bo-crit-ink); }
+  &--info { --bo-stat-c: var(--bo-info-ink); }
+  &--accent { --bo-stat-c: var(--bo-accent-soft-ink); }
 }
 
 // =============================================================================
@@ -732,6 +823,14 @@
     > tbody > tr > td:last-child {
       padding-right: 16px !important;
     }
+  }
+
+  // Table dense (8 colonnes et plus) : en-dessous de cette largeur les colonnes
+  // s'écrasent et tout se met à passer à la ligne — codes voyage, pastilles
+  // d'état, montants. Mieux vaut un ascenseur horizontal, que le conteneur de
+  // Vuetify fournit déjà.
+  &--wide .v-table__wrapper > table {
+    min-width: 1080px;
   }
 
   .v-data-table__td--select-row,
@@ -970,8 +1069,9 @@
     font-weight: 600;
     letter-spacing: -0.02em;
 
-    &--ok { color: var(--bo-ok); }
-    &--warn { color: var(--bo-warn); }
+    // Valeurs de texte : jamais l'aplat vif, qui ne passe pas 4,5:1 sur blanc.
+    &--ok { color: var(--bo-ok-ink); }
+    &--warn { color: var(--bo-warn-ink); }
   }
 }
 
@@ -1096,7 +1196,7 @@
     .bo-due {
       display: block;
       font-size: 10.5px;
-      color: var(--bo-warn);
+      color: var(--bo-warn-ink);
     }
   }
 }
@@ -1163,16 +1263,21 @@
   // rayon du thème vitrine (jusqu'à 10 px sur les champs). Neutraliser par
   // props ne suffit pas : les defaults du plugin global fusionnent avec ceux du
   // <v-defaults-provider>. On reprend donc la main ici, une fois pour toutes.
-  .v-field,
-  .v-btn,
-  .v-chip,
   .v-card,
   .v-sheet {
     border-radius: var(--bo-radius) !important;
   }
 
-  .v-chip {
+  // Un contrôle est moins arrondi que la surface qui le porte, sinon il paraît
+  // plus gros qu'elle.
+  .v-field,
+  .v-btn {
     border-radius: var(--bo-radius-s) !important;
+  }
+
+  // Un chip du backoffice ne sert qu'à porter un état : même forme que .bo-tag.
+  .v-chip {
+    border-radius: var(--bo-radius-pill) !important;
   }
 
   // --- Champs ---
@@ -1308,10 +1413,10 @@
 
   // --- Chips : seulement pour de l'état, toujours carrés ---
   .v-chip {
-    padding: 0 7px !important;
+    padding: 0 8px !important;
     font-size: 10.5px;
     font-weight: 600;
-    letter-spacing: 0.04em;
+    letter-spacing: 0;
   }
 
   // --- Contrôle segmenté (v-btn-toggle) : un seul choix parmi n, dense ---
@@ -1321,14 +1426,14 @@
     gap: 2px;
     background: var(--bo-control);
     border: 1px solid var(--bo-field-line);
-    border-radius: var(--bo-radius);
+    border-radius: var(--bo-radius-pill);
 
     .v-btn {
       height: 26px !important;
       min-width: 0;
       padding: 0 12px;
       border: 0 !important;
-      border-radius: var(--bo-radius-s) !important;
+      border-radius: var(--bo-radius-pill) !important;
       color: var(--bo-ink-2);
       font-size: 12px;
 
@@ -1436,6 +1541,349 @@
 }
 
 // =============================================================================
+// Poste de pilotage
+//
+// Ce qui suit n'existe que pour l'écran Sales, mais vit ici plutôt qu'en
+// <style scoped> : ce sont des règles de système (catégories opérationnelles,
+// lecture d'un remplissage, hiérarchie d'un libellé de voyage) qui ont vocation
+// à resservir dès qu'un autre écran affichera des départs.
+//
+// Les quatre catégories opérationnelles et leur couleur, dans l'ordre de
+// priorité — sécuriser, puis optimiser, puis arbitrer, puis tout voir :
+//   à garantir  vert    le départ se confirme à la prochaine vente
+//   à maximiser indigo  déjà garanti, il reste de la marge à prendre
+//   à décider   bleu    l'échéance J‑30 arrive, il faut trancher
+//   tous        gris    tableau exhaustif, aucune priorité
+// =============================================================================
+
+// --- Bandeau de tête : le chiffre qui justifie l'écran ---------------------
+.bo-hero {
+  background: var(--bo-accent-grad);
+  color: #fff;
+  border-radius: var(--bo-radius);
+  padding: 16px 20px;
+  box-shadow: var(--bo-shadow);
+
+  &__n {
+    font-family: var(--bo-ff-data);
+    font-variant-numeric: tabular-nums;
+    font-size: 30px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1;
+  }
+
+  &__l {
+    margin-top: 5px;
+    font-size: 12.5px;
+    opacity: 0.92;
+
+    b {
+      opacity: 1;
+      font-weight: 600;
+    }
+  }
+}
+
+// --- Encart de règle métier -----------------------------------------------
+// Une note, pas une alerte : elle explique comment lire l'écran et reste à
+// l'écran en permanence. D'où l'indigo (l'outil) plutôt qu'une sémantique.
+.bo-note {
+  padding: 9px 14px;
+  border: 1px solid var(--bo-accent-line);
+  border-radius: var(--bo-radius-s);
+  background: var(--bo-accent-soft);
+  color: var(--bo-accent-soft-ink);
+  font-size: 12px;
+}
+
+// --- Sélecteur de plage ----------------------------------------------------
+// Le libellé vit au-dessus de la valeur, dans le champ : la date est le
+// contenu, pas une saisie de formulaire parmi d'autres.
+.bo-daterange {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.bo-datefield {
+  border: 1px solid var(--bo-line);
+  background: var(--bo-field);
+  border-radius: var(--bo-radius-s);
+  padding: 6px 13px 7px;
+  box-shadow: var(--bo-shadow);
+
+  label {
+    display: block;
+    font-size: 9.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--bo-ink-3);
+  }
+
+  input {
+    border: 0;
+    outline: none;
+    background: transparent;
+    padding: 0;
+    font-family: var(--bo-ff-data);
+    font-variant-numeric: tabular-nums;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--bo-ink);
+  }
+
+  &:focus-within {
+    border-color: var(--bo-accent);
+  }
+}
+
+// --- Onglets de catégorie --------------------------------------------------
+// Collants : on change d'onglet en permanence, et la table sous-jacente est
+// longue. L'onglet actif prend la couleur pleine de sa catégorie — c'est le
+// seul repère qui dit dans quelle intention on lit le tableau.
+.bo-tabs {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 0;
+  margin-bottom: 4px;
+  background: color-mix(in srgb, var(--bo-paper) 95%, transparent);
+  backdrop-filter: blur(4px);
+  border-bottom: 1px solid var(--bo-line);
+
+  &__t {
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--bo-ink);
+    background: var(--bo-surface);
+    border: 1px solid var(--bo-line);
+    border-radius: var(--bo-radius-pill);
+    padding: 7px 13px;
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--bo-ink-2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--bo-accent);
+      outline-offset: 2px;
+    }
+
+    &[aria-selected='true'] {
+      background: var(--bo-tab-c, var(--bo-ink-2));
+      border-color: var(--bo-tab-c, var(--bo-ink-2));
+      color: #fff;
+    }
+
+    &--ok { --bo-tab-c: var(--bo-ok); }
+    &--accent { --bo-tab-c: var(--bo-accent); }
+    &--info { --bo-tab-c: var(--bo-info); }
+    &--neutral { --bo-tab-c: var(--bo-ink-2); }
+  }
+
+  &__n {
+    margin-left: 6px;
+    font-family: var(--bo-ff-data);
+    font-size: 11px;
+    opacity: 0.75;
+  }
+}
+
+// --- Filtres secondaires ---------------------------------------------------
+.bo-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+}
+
+.bo-chip {
+  border: 1px solid var(--bo-line);
+  background: var(--bo-surface);
+  border-radius: var(--bo-radius-pill);
+  padding: 6px 12px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--bo-ink-3);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--bo-ink);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--bo-accent);
+    outline-offset: 2px;
+  }
+
+  &[aria-pressed='true'] {
+    background: var(--bo-ink-2);
+    border-color: var(--bo-ink-2);
+    color: #fff;
+  }
+
+  // Filtre de moteur (GIR / co-remplissage) : indigo, pour se distinguer des
+  // filtres de catégorie posés juste à côté.
+  &--accent {
+    font-weight: 600;
+
+    &[aria-pressed='true'] {
+      background: var(--bo-accent);
+      border-color: var(--bo-accent);
+    }
+  }
+}
+
+// --- Libellé de voyage -----------------------------------------------------
+// Le code BMS « Pays - CODE » est l'identifiant de travail : c'est lui qu'on
+// cherche du regard, le titre commercial ne sert qu'à lever un doute.
+.bo-voyage {
+  &__code {
+    font-weight: 600;
+    letter-spacing: -0.01em;
+
+    // Un code coupé en deux (« Tanzanie - AF- / TZA-01 ») cesse d'être un
+    // identifiant : il ne se reconnaît plus d'un coup d'œil et ne se dicte
+    // plus. La table déborde en scroll horizontal plutôt que de le casser.
+    white-space: nowrap;
+  }
+
+  &__title {
+    display: block;
+    margin-top: 1px;
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--bo-ink-3);
+  }
+}
+
+// --- Barre de sièges -------------------------------------------------------
+// Variante de .bo-fill pour un départ : elle se lit en places vendues sur la
+// capacité, et porte les repères de sièges pairs. La marge marginale d'un
+// siège pair vaut environ le double d'un impair (effet chambre double) : ces
+// repères indiquent où pousser la prochaine vente.
+.bo-seats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+
+  &__bar {
+    position: relative;
+    flex: none;
+    width: 56px;
+    height: 6px;
+    border-radius: var(--bo-radius-pill);
+    background: var(--bo-neutral-soft);
+    overflow: hidden;
+  }
+
+  &__in {
+    display: block;
+    height: 100%;
+    background: var(--bo-accent);
+
+    // Seuil de garantie atteint : la jauge passe au vert, sans autre signal.
+    &--guaranteed { background: var(--bo-ok); }
+  }
+
+  &__tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: #0000001f;
+
+    &--even {
+      width: 2px;
+      background: color-mix(in srgb, var(--bo-accent) 65%, transparent);
+    }
+  }
+
+  &__n {
+    font-family: var(--bo-ff-data);
+    font-variant-numeric: tabular-nums;
+    font-size: 11.5px;
+    color: var(--bo-ink-2);
+
+    b {
+      color: var(--bo-ink);
+      font-weight: 600;
+    }
+  }
+}
+
+:root[data-bo-theme='dark'] .bo-seats__tick {
+  background: #ffffff29;
+}
+
+// --- Pastille de moteur de remplissage -------------------------------------
+// GIR = nos propres inscrits, marge Odysway. Co-remp = places garanties par un
+// partenaire, marge fixe : hors des départs à optimiser.
+.bo-motor {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: var(--bo-radius-s);
+  white-space: nowrap;
+
+  &--gir { background: var(--bo-accent-soft); color: var(--bo-accent-soft-ink); }
+  &--co { background: var(--bo-info-soft); color: var(--bo-info-ink); }
+}
+
+// --- Palier de marge -------------------------------------------------------
+.bo-step {
+  white-space: nowrap;
+  font-size: 12px;
+
+  b {
+    color: var(--bo-accent-soft-ink);
+  }
+}
+
+// --- Montant --------------------------------------------------------------
+.bo-eur {
+  font-family: var(--bo-ff-data);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+// --- En-tête de bloc -------------------------------------------------------
+.bo-blkhead {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+
+  h2 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  &__c {
+    color: var(--bo-ink-3);
+    font-size: 12.5px;
+  }
+}
+
+// Bande de catégorie sur la première cellule d'une ligne de départ.
+.bo-tr {
+  &--seg-ok { --bo-st: var(--bo-ok); }
+  &--seg-accent { --bo-st: var(--bo-accent); }
+  &--seg-info { --bo-st: var(--bo-info); }
+}
+
+// =============================================================================
 // Adaptatif
 // =============================================================================
 
@@ -1446,10 +1894,7 @@
 }
 
 @media (max-width: 959px) {
-  .bo-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
+  // .bo-stats se réorganise seul (auto-fit / minmax) : rien à forcer ici.
   .bo-grid-2,
   .bo-grid-3 {
     grid-template-columns: 1fr;

--- a/app/components/booking/BoDepartureActions.vue
+++ b/app/components/booking/BoDepartureActions.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="d-flex justify-end ga-2">
+    <v-btn
+      :href="prospectsHref"
+      target="_blank"
+      rel="noopener"
+      @click.stop
+    >
+      Prospects
+    </v-btn>
+    <v-btn
+      color="primary"
+      variant="flat"
+      @click.stop="$emit('open')"
+    >
+      Ouvrir
+    </v-btn>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// Les deux gestes possibles sur un départ : aller chercher de la demande
+// (prospects) ou aller travailler le départ lui-même.
+//
+// « Prospects » pointe pour l'instant sur une recherche ActiveCampaign par
+// titre de voyage. Le rapprochement réel — compteurs par type, déduplication,
+// liste filtrée sur le départ — fait l'objet de la spéc « Prospects
+// ActiveCampaign », qui n'est pas encore implémentée : ce lien est un
+// dépannage assumé, à remplacer quand l'endpoint existera.
+const AC_SEARCH_BASE = 'https://odysway.activehosted.com/app/contacts/'
+
+const props = defineProps({
+  query: { type: String, default: '' }
+})
+
+defineEmits(['open'])
+
+const prospectsHref = computed(() => `${AC_SEARCH_BASE}?q=${encodeURIComponent(props.query)}`)
+</script>

--- a/app/components/booking/BoSeatBar.vue
+++ b/app/components/booking/BoSeatBar.vue
@@ -1,0 +1,79 @@
+<template>
+  <span
+    v-if="!max"
+    class="bo-hint"
+  >—</span>
+  <div
+    v-else
+    class="bo-seats"
+  >
+    <span
+      class="bo-seats__bar"
+      role="img"
+      :aria-label="label"
+    >
+      <i
+        class="bo-seats__in"
+        :class="guaranteed ? 'bo-seats__in--guaranteed' : ''"
+        :style="{ width: `${percent}%` }"
+      />
+      <span
+        v-for="tick in ticks"
+        :key="tick.seat"
+        class="bo-seats__tick"
+        :class="tick.even ? 'bo-seats__tick--even' : ''"
+        :style="{ left: `${tick.left}%` }"
+      />
+    </span>
+    <span
+      class="bo-seats__n"
+      aria-hidden="true"
+    >
+      <b>{{ realPax }}</b> Ody<template v-if="partners > 0"> · {{ partners }} part.</template> / {{ max }}
+    </span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// Remplissage d'un départ.
+//
+// Deux choses se lisent d'un coup d'œil : où on en est par rapport à la
+// capacité, et où tombe le prochain siège pair. La marge marginale d'un siège
+// pair vaut environ le double d'un impair (effet chambre double), donc c'est
+// vers un pair qu'il faut pousser la prochaine vente — les repères épais.
+//
+// La jauge mesure `booked` (nos inscrits + les places partenaires), parce que
+// c'est ce total qui déclenche la garantie ; le compteur à droite, lui, sépare
+// les deux, parce que seuls nos inscrits sont actionnables.
+const props = defineProps({
+  booked: { type: Number, default: 0 },
+  realPax: { type: Number, default: 0 },
+  partners: { type: Number, default: 0 },
+  max: { type: Number, default: 0 },
+  guaranteed: { type: Boolean, default: false },
+})
+
+const percent = computed(() => {
+  if (!props.max) return 0
+  return Math.min(100, Math.round((props.booked / props.max) * 100))
+})
+
+// Au-delà d'une vingtaine de sièges les repères se touchent sur 56 px de barre
+// et ne forment plus qu'un aplat : on les retire plutôt que d'afficher du bruit.
+const ticks = computed(() => {
+  if (!props.max || props.max > 20) return []
+  const out = []
+  for (let seat = 1; seat < props.max; seat++) {
+    out.push({ seat, even: seat % 2 === 0, left: (seat / props.max) * 100 })
+  }
+  return out
+})
+
+const label = computed(() => {
+  const parts = [`${props.realPax} voyageur${props.realPax > 1 ? 's' : ''} Odysway`]
+  if (props.partners > 0) parts.push(`${props.partners} place${props.partners > 1 ? 's' : ''} partenaire`)
+  return `${parts.join(', ')} sur ${props.max} places${props.guaranteed ? ' — départ garanti' : ''}`
+})
+</script>

--- a/app/components/booking/BoVoyageLabel.vue
+++ b/app/components/booking/BoVoyageLabel.vue
@@ -1,0 +1,28 @@
+<template>
+  <span
+    v-if="!code"
+    class="bo-voyage__code"
+  >{{ title }}</span>
+  <span
+    v-else
+    class="bo-voyage"
+  >
+    <span class="bo-voyage__code">{{ code }}</span>
+    <span :class="inline ? 'bo-muted ml-2' : 'bo-voyage__title'">{{ title }}</span>
+  </span>
+</template>
+
+<script setup>
+// Libellé d'un voyage dans une liste de départs.
+//
+// Le code BMS (« Pays - CODE », ex. « France - FR-BER-01 ») porte l'identité :
+// c'est lui qu'on cherche du regard dans une liste longue, et lui qu'on dicte
+// au téléphone. Le titre commercial ne sert qu'à lever un doute, il passe donc
+// en appui — sur une seconde ligne, ou sur la même quand la table est déjà
+// dense (`inline`).
+defineProps({
+  code: { type: String, default: '' },
+  title: { type: String, default: '' },
+  inline: { type: Boolean, default: false }
+})
+</script>

--- a/app/components/booking/MarginsDashboard.vue
+++ b/app/components/booking/MarginsDashboard.vue
@@ -75,10 +75,7 @@
       </div>
 
       <!-- KPI cards -->
-      <section
-        class="bo-stats mb-4"
-        style="--bo-stats-cols: 3;"
-      >
+      <section class="bo-stats mb-4">
         <div class="bo-stat">
           <div class="bo-stat__k">
             Marge estimée totale

--- a/app/layouts/booking.vue
+++ b/app/layouts/booking.vue
@@ -176,6 +176,7 @@ import {
   mdiDeleteRestore,
   mdiWeatherNight,
   mdiWeatherSunny,
+  mdiBullseyeArrow,
 } from '@mdi/js'
 import BoDialogHost from '~/components/booking/BoDialogHost.vue'
 import '@/assets/scss/backoffice.scss'
@@ -192,21 +193,21 @@ if (!theme.themes.value.backoffice) {
   theme.themes.value.backoffice = {
     dark: false,
     colors: {
-      'primary': '#2B4C52',
-      'secondary': '#5B7075',
-      'background': '#F1F4F4',
+      'primary': '#5B5BD6',
+      'secondary': '#4B5563',
+      'background': '#F5F6F8',
       'surface': '#FFFFFF',
-      'surface-variant': '#F7F9F9',
-      'on-background': '#16262B',
-      'on-surface': '#16262B',
-      'success': '#0B7A4B',
-      'warning': '#C2410C',
-      'error': '#C0261F',
-      'info': '#0B6BCB',
+      'surface-variant': '#FAFBFC',
+      'on-background': '#1B1D23',
+      'on-surface': '#1B1D23',
+      'success': '#12A150',
+      'warning': '#E5920A',
+      'error': '#E5484D',
+      'info': '#0E7FE1',
     },
     variables: {
       'medium-emphasis-opacity': 0.75,
-      'border-color': '#DDE4E4',
+      'border-color': '#ECEEF2',
       'border-opacity': 1,
     },
   }
@@ -215,21 +216,21 @@ if (!theme.themes.value['backoffice-dark']) {
   theme.themes.value['backoffice-dark'] = {
     dark: true,
     colors: {
-      'primary': '#78ADB3',
-      'secondary': '#94AAAF',
-      'background': '#0D171B',
-      'surface': '#142329',
-      'surface-variant': '#1A2C33',
-      'on-background': '#E2EAEA',
-      'on-surface': '#E2EAEA',
+      'primary': '#8B8BE8',
+      'secondary': '#A8B0BF',
+      'background': '#0F1116',
+      'surface': '#171A21',
+      'surface-variant': '#1C2029',
+      'on-background': '#E7E9EF',
+      'on-surface': '#E7E9EF',
       'success': '#34D399',
-      'warning': '#FFA726',
+      'warning': '#FBBF24',
       'error': '#F87171',
       'info': '#60A5FA',
     },
     variables: {
       'medium-emphasis-opacity': 0.75,
-      'border-color': '#24393F',
+      'border-color': '#272C36',
       'border-opacity': 1,
     },
   }
@@ -308,6 +309,14 @@ const drawer = ref(true)
 const railMode = ref(false)
 
 const navGroups = [
+  {
+    // Le poste de pilotage vient en premier : c'est l'écran depuis lequel on
+    // décide quoi faire de sa journée, les autres servent à exécuter.
+    label: 'Pilotage',
+    items: [
+      { title: 'Sales', icon: mdiBullseyeArrow, to: '/booking-management/sales', exact: false },
+    ],
+  },
   {
     label: 'Exploitation',
     items: [

--- a/app/pages/booking-management/departures.vue
+++ b/app/pages/booking-management/departures.vue
@@ -16,10 +16,7 @@
     </BoPageHeader>
 
     <div class="bo-well">
-      <section
-        class="bo-stats"
-        style="--bo-stats-cols: 3;"
-      >
+      <section class="bo-stats">
         <div class="bo-stat">
           <div class="bo-stat__k">
             Sans dossier

--- a/app/pages/booking-management/sales.vue
+++ b/app/pages/booking-management/sales.vue
@@ -1,0 +1,751 @@
+<template>
+  <div>
+    <BoPageHeader
+      title="Sales — pilotage des départs"
+      :subtitle="subtitle"
+      :crumbs="[{ title: 'Backoffice', to: '/booking-management' }, { title: 'Sales' }]"
+    >
+      <template #actions>
+        <v-btn
+          :prepend-icon="mdiRefresh"
+          :loading="loading"
+          @click="fetchRows"
+        >
+          Actualiser
+        </v-btn>
+      </template>
+    </BoPageHeader>
+
+    <div class="bo-well">
+      <!-- Le chiffre qui justifie l'écran : la marge qui dort dans les sièges
+           vides des départs encore à venir. -->
+      <section class="bo-hero">
+        <div class="bo-hero__n">
+          {{ formatEur(dormant.total) }}
+        </div>
+        <div class="bo-hero__l">
+          de marge quasi-pure dorment dans les sièges vides ·
+          <b>GIR propres {{ formatEur(dormant.gir) }}</b> ·
+          co-remplissage {{ formatEur(dormant.co) }} ·
+          pousser au prochain siège pair d'abord
+        </div>
+      </section>
+
+      <p class="bo-note">
+        <b>Règle du siège pair</b> — la marge marginale des sièges pairs (2/4/6/8) vaut
+        environ le double de celle des impairs (effet chambre double). Le « prochain
+        palier rentable » tombe donc presque toujours sur un siège pair :
+        <b>c'est là qu'il faut pousser en priorité</b>. Les repères épais sur les barres
+        de remplissage marquent ces sièges. Priorité aux départs
+        <span class="bo-motor bo-motor--gir">GIR</span> (marge Odysway) sur les
+        <span class="bo-motor bo-motor--co">co-remp</span> (marge partenaire fixe).
+      </p>
+
+      <!-- Plage de dates : rechargée côté serveur, ce n'est pas un filtre local. -->
+      <form
+        class="bo-daterange"
+        @submit.prevent="applyRange"
+      >
+        <div class="bo-datefield">
+          <label for="pilotage-from">Depuis</label>
+          <input
+            id="pilotage-from"
+            v-model="draftFrom"
+            type="date"
+          >
+        </div>
+        <div class="bo-datefield">
+          <label for="pilotage-to">Jusqu'au</label>
+          <input
+            id="pilotage-to"
+            v-model="draftTo"
+            type="date"
+          >
+        </div>
+        <v-btn
+          type="submit"
+          :loading="loading"
+        >
+          Appliquer
+        </v-btn>
+      </form>
+
+      <div
+        v-if="loading"
+        class="d-flex justify-center py-12"
+      >
+        <v-progress-circular
+          indeterminate
+          color="primary"
+          size="40"
+        />
+      </div>
+
+      <div
+        v-else-if="error"
+        class="bo-notice bo-notice--crit"
+      >
+        <v-icon
+          size="18"
+          :icon="mdiAlertCircleOutline"
+        />
+        <div class="bo-notice__body">
+          <div class="bo-notice__title">
+            Chargement impossible
+          </div>
+          <div class="bo-notice__meta">
+            {{ error }}
+          </div>
+        </div>
+        <div class="bo-notice__actions">
+          <v-btn @click="fetchRows">
+            Réessayer
+          </v-btn>
+        </div>
+      </div>
+
+      <template v-else>
+        <!-- Ordre imposé : sécuriser, puis optimiser, puis arbitrer, puis tout
+             voir. L'onglet actif porte la couleur pleine de sa catégorie. -->
+        <div
+          class="bo-tabs"
+          role="tablist"
+          aria-label="Catégories de départs"
+        >
+          <button
+            v-for="t in TABS"
+            :key="t.id"
+            type="button"
+            role="tab"
+            class="bo-tabs__t"
+            :class="`bo-tabs__t--${t.tone}`"
+            :aria-selected="tab === t.id"
+            @click="tab = t.id"
+          >
+            {{ t.label }}
+            <span class="bo-tabs__n">{{ counts[t.id] }}</span>
+          </button>
+        </div>
+
+        <section class="bo-stats">
+          <div class="bo-stat bo-stat--ok">
+            <div class="bo-stat__k">
+              Départs à garantir
+            </div>
+            <div class="bo-stat__v">
+              {{ counts.sauver }}
+            </div>
+            <div class="bo-stat__n">
+              une vente suffit à confirmer le départ
+            </div>
+          </div>
+          <div class="bo-stat bo-stat--accent">
+            <div class="bo-stat__k">
+              Marge additionnelle
+            </div>
+            <div class="bo-stat__v">
+              {{ formatEur(kpis.remaining) }}
+            </div>
+            <div class="bo-stat__n">
+              sur les départs déjà garantis
+            </div>
+          </div>
+          <div class="bo-stat bo-stat--warn">
+            <div class="bo-stat__k">
+              Potentiel +1 vente
+            </div>
+            <div class="bo-stat__v">
+              {{ formatEur(kpis.nextSale) }}
+            </div>
+            <div class="bo-stat__n">
+              une vente de plus sur chaque départ actionnable
+            </div>
+          </div>
+          <div class="bo-stat bo-stat--info">
+            <div class="bo-stat__k">
+              Décisions à prendre
+            </div>
+            <div class="bo-stat__v">
+              {{ counts.decider }}
+            </div>
+            <div class="bo-stat__n">
+              échéance J‑{{ DECISION_LEAD_DAYS }} atteinte ou proche
+            </div>
+          </div>
+        </section>
+
+        <!-- À garantir / À décider : mêmes colonnes, mêmes gestes. -->
+        <section
+          v-if="tab === 'sauver' || tab === 'decider'"
+          class="bo-card"
+        >
+          <div class="bo-card__head">
+            <div class="bo-blkhead">
+              <h2>{{ activeTab.label }}</h2>
+              <span class="bo-blkhead__c">{{ visibleRows.length }} départ{{ visibleRows.length > 1 ? 's' : '' }}</span>
+            </div>
+          </div>
+
+          <v-table class="bo-table">
+            <thead>
+              <tr>
+                <th>Voyage</th>
+                <th>Départ</th>
+                <th>Échéance</th>
+                <th>Remplissage</th>
+                <th>Objectif</th>
+                <th class="text-right">
+                  Prochaine vente
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in shownRows"
+                :key="row.travel_date_id"
+                class="bo-tr"
+                :class="`bo-tr--seg-${activeTab.tone}`"
+                @click="openDeparture(row)"
+              >
+                <td>
+                  <BoVoyageLabel v-bind="metaFor(row.slug)" />
+                </td>
+                <td class="bo-num bo-muted">
+                  {{ formatDay(row.date) }} · J‑{{ row.days_to_departure }}
+                </td>
+                <td>
+                  <span
+                    class="bo-tag"
+                    :class="deadline(row).cls"
+                  >{{ deadline(row).text }}</span>
+                </td>
+                <td>
+                  <BoSeatBar v-bind="seatProps(row)" />
+                </td>
+                <td>
+                  manque <b>{{ row.missing }}</b> pax
+                </td>
+                <td class="text-right bo-eur">
+                  <span v-if="row.next_sale_gain > 0">+{{ formatEur(row.next_sale_gain) }}</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="text-right">
+                  <BoDepartureActions
+                    :query="metaFor(row.slug).title"
+                    @open="openDeparture(row)"
+                  />
+                </td>
+              </tr>
+              <tr v-if="!shownRows.length">
+                <td colspan="7">
+                  <div class="bo-empty">
+                    Aucun départ dans cette catégorie sur la plage choisie.
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div
+            v-if="hasMore"
+            class="pa-3"
+          >
+            <button
+              type="button"
+              class="bo-chip bo-chip--accent"
+              @click="showAll = true"
+            >
+              Voir les {{ visibleRows.length }} départs →
+            </button>
+          </div>
+        </section>
+
+        <!-- À maximiser : le départ est acquis, la question est combien il rapporte. -->
+        <section
+          v-else-if="tab === 'maximiser'"
+          class="bo-card"
+        >
+          <div class="bo-card__head">
+            <div class="bo-blkhead">
+              <h2>{{ activeTab.label }}</h2>
+              <span class="bo-blkhead__c">{{ visibleRows.length }} départ{{ visibleRows.length > 1 ? 's' : '' }}</span>
+            </div>
+          </div>
+
+          <v-table class="bo-table">
+            <thead>
+              <tr>
+                <th>Voyage</th>
+                <th>Départ</th>
+                <th>Remplissage</th>
+                <th class="text-right">
+                  Prochaine vente
+                </th>
+                <th>Prochain palier rentable</th>
+                <th class="text-right">
+                  Potentiel restant
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in shownRows"
+                :key="row.travel_date_id"
+                class="bo-tr bo-tr--seg-accent"
+                @click="openDeparture(row)"
+              >
+                <td>
+                  <BoVoyageLabel v-bind="metaFor(row.slug)" />
+                </td>
+                <td class="bo-num bo-muted">
+                  {{ formatDay(row.date) }}
+                </td>
+                <td>
+                  <BoSeatBar v-bind="seatProps(row)" />
+                </td>
+                <td class="text-right bo-eur">
+                  <span v-if="row.next_sale_gain > 0">+{{ formatEur(row.next_sale_gain) }}</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td>
+                  <span
+                    v-if="row.step"
+                    class="bo-step"
+                  >
+                    <b>{{ row.step }} pax</b> · {{ row.step_sales }} vente{{ row.step_sales > 1 ? 's' : '' }} ·
+                    +{{ formatEur(row.step_gain) }}
+                  </span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="text-right bo-eur">
+                  <span v-if="row.remaining_potential > 0">{{ formatEur(row.remaining_potential) }}</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="text-right">
+                  <BoDepartureActions
+                    :query="metaFor(row.slug).title"
+                    @open="openDeparture(row)"
+                  />
+                </td>
+              </tr>
+              <tr v-if="!shownRows.length">
+                <td colspan="7">
+                  <div class="bo-empty">
+                    Aucun départ garanti avec du potentiel restant sur cette plage.
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div
+            v-if="hasMore"
+            class="pa-3"
+          >
+            <button
+              type="button"
+              class="bo-chip bo-chip--accent"
+              @click="showAll = true"
+            >
+              Voir les {{ visibleRows.length }} départs →
+            </button>
+          </div>
+        </section>
+
+        <!-- Tous les départs : le tableau exhaustif, y compris ce qui n'entre
+             dans aucun onglet d'action (co-remplissage, sans traction, non suivi). -->
+        <section
+          v-else
+          class="bo-card"
+        >
+          <div class="bo-card__head">
+            <div class="bo-blkhead">
+              <h2>Tous les départs</h2>
+              <span class="bo-blkhead__c">{{ visibleRows.length }} sur {{ rows.length }}</span>
+            </div>
+          </div>
+
+          <div class="bo-card__body pb-0">
+            <div class="bo-chips">
+              <button
+                v-for="f in SEGMENT_FILTERS"
+                :key="f.id"
+                type="button"
+                class="bo-chip"
+                :aria-pressed="segmentFilter === f.id"
+                @click="segmentFilter = f.id"
+              >
+                {{ f.label }}
+              </button>
+              <span class="flex-grow-1" />
+              <button
+                v-for="m in MOTOR_FILTERS"
+                :key="m.id"
+                type="button"
+                class="bo-chip bo-chip--accent"
+                :aria-pressed="motorFilter === m.id"
+                @click="motorFilter = m.id"
+              >
+                {{ m.label }}
+              </button>
+            </div>
+          </div>
+
+          <v-table class="bo-table bo-table--wide">
+            <thead>
+              <tr>
+                <th>Départ</th>
+                <th>Voyage</th>
+                <th>J‑ départ</th>
+                <th>Statut</th>
+                <th>Ody / Total / Max</th>
+                <th class="text-right">
+                  Prochaine vente
+                </th>
+                <th>Palier</th>
+                <th class="text-right">
+                  Potentiel restant
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in shownRows"
+                :key="row.travel_date_id"
+                class="bo-tr"
+                @click="openDeparture(row)"
+              >
+                <td class="bo-num bo-muted">
+                  {{ formatDay(row.date) }}
+                </td>
+                <td>
+                  <BoVoyageLabel
+                    v-bind="metaFor(row.slug)"
+                    :inline="true"
+                  />
+                </td>
+                <td class="bo-muted">
+                  J‑{{ row.days_to_departure }}
+                </td>
+                <td>
+                  <span
+                    class="bo-tag"
+                    :class="status(row).cls"
+                  >{{ status(row).text }}</span>
+                  <span
+                    class="bo-motor ml-2"
+                    :class="row.co_filling ? 'bo-motor--co' : 'bo-motor--gir'"
+                  >{{ row.co_filling ? 'co-remp' : 'GIR' }}</span>
+                </td>
+                <td class="bo-num bo-muted">
+                  {{ row.real_pax }} / {{ row.booked }} / {{ row.max }}
+                </td>
+                <td class="text-right bo-eur">
+                  <span v-if="row.next_sale_gain > 0">+{{ formatEur(row.next_sale_gain) }}</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="bo-step">
+                  <span v-if="row.step">{{ row.step }} pax (+{{ formatEur(row.step_gain) }})</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="text-right bo-eur">
+                  <span v-if="row.remaining_potential > 0">{{ formatEur(row.remaining_potential) }}</span>
+                  <span
+                    v-else
+                    class="bo-muted"
+                  >—</span>
+                </td>
+                <td class="text-right">
+                  <BoDepartureActions
+                    :query="metaFor(row.slug).title"
+                    @open="openDeparture(row)"
+                  />
+                </td>
+              </tr>
+              <tr v-if="!shownRows.length">
+                <td colspan="9">
+                  <div class="bo-empty">
+                    Aucun départ ne correspond à ces filtres.
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+
+          <div
+            v-if="hasMore"
+            class="pa-3"
+          >
+            <button
+              type="button"
+              class="bo-chip bo-chip--accent"
+              @click="showAll = true"
+            >
+              Voir les {{ visibleRows.length }} départs →
+            </button>
+          </div>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import dayjs from 'dayjs'
+import { stegaClean } from '@sanity/client/stega'
+import { mdiRefresh, mdiAlertCircleOutline } from '@mdi/js'
+import BoPageHeader from '~/components/booking/BoPageHeader.vue'
+import BoSeatBar from '~/components/booking/BoSeatBar.vue'
+import BoVoyageLabel from '~/components/booking/BoVoyageLabel.vue'
+import BoDepartureActions from '~/components/booking/BoDepartureActions.vue'
+import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
+import { formatEur } from '~/utils/formatNumber'
+
+definePageMeta({
+  layout: 'booking',
+  middleware: 'booking-management'
+})
+
+useSeoMeta({
+  htmlAttrs: { lang: 'fr' },
+  robots: 'noindex, follow'
+})
+
+// Doit rester aligné sur DECISION_LEAD_DAYS de l'endpoint : c'est le même
+// arbitrage métier, calculé là-bas et seulement affiché ici.
+const DECISION_LEAD_DAYS = 30
+
+// Au-delà, la table cesse d'être un plan de travail et devient un export. Le
+// bouton « voir tout » reste là pour ceux qui veulent balayer.
+const PAGE_SIZE = 25
+
+const TABS = [
+  { id: 'sauver', label: 'À garantir', tone: 'ok' },
+  { id: 'maximiser', label: 'À maximiser', tone: 'accent' },
+  { id: 'decider', label: 'À décider', tone: 'info' },
+  { id: 'tous', label: 'Tous les départs', tone: 'neutral' }
+]
+
+const SEGMENT_FILTERS = [
+  { id: 'all', label: 'Tous' },
+  { id: 'sauver', label: 'À garantir' },
+  { id: 'maximiser', label: 'À maximiser' },
+  { id: 'decider', label: 'À décider' },
+  { id: 'non_garanti', label: 'Non garanti' },
+  { id: 'sans_traction', label: 'Sans traction' },
+  { id: 'non_suivi', label: 'Non suivi' }
+]
+
+const MOTOR_FILTERS = [
+  { id: 'all', label: 'Tous moteurs' },
+  { id: 'gir', label: 'GIR propres' },
+  { id: 'coremp', label: 'Co-remp' }
+]
+
+const router = useRouter()
+const sanity = useSanity()
+
+const loading = ref(true)
+const error = ref('')
+const rows = ref([])
+const tab = ref('sauver')
+const segmentFilter = ref('all')
+const motorFilter = ref('all')
+const showAll = ref(false)
+
+// La plage part d'aujourd'hui : le pilotage ne regarde que devant. Le passé se
+// lit dans le dashboard des marges, qui est un outil de bilan.
+const from = ref(dayjs().format('YYYY-MM-DD'))
+const to = ref(dayjs().add(6, 'month').format('YYYY-MM-DD'))
+const draftFrom = ref(from.value)
+const draftTo = ref(to.value)
+
+// --- Métadonnées voyage (Sanity) -------------------------------------------
+const voyageMetaQuery = groq`*[_type == "voyage" && defined(slug.current)]{
+  "slug": slug.current,
+  title,
+  bmsReference,
+  "country": destinations[0]->title
+}`
+const { data: voyageMetaList } = await useAsyncData('salesVoyageMeta', () => sanity.fetch(voyageMetaQuery))
+
+const metaBySlug = computed(() => {
+  const map = new Map()
+  for (const v of voyageMetaList.value || []) {
+    // Hors production, chaque chaîne Sanity transporte des caractères de
+    // largeur nulle (stega) qui casseraient la concaténation du code.
+    const slug = stegaClean(v.slug)
+    if (!slug) continue
+    const reference = stegaClean(v.bmsReference) || ''
+    const country = stegaClean(v.country) || ''
+    map.set(slug, {
+      title: stegaClean(v.title) || slug,
+      code: reference ? [country, reference].filter(Boolean).join(' - ') : ''
+    })
+  }
+  return map
+})
+
+const metaFor = slug => metaBySlug.value.get(slug) || { title: slug, code: '' }
+
+// --- Données ---------------------------------------------------------------
+const fetchRows = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const data = await bookingApi.getMarginsPilotage({ from: from.value, to: to.value })
+    rows.value = data.rows || []
+  }
+  catch (err) {
+    error.value = getApiErrorMessage(err, 'Erreur chargement du poste de pilotage.')
+    rows.value = []
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+const applyRange = () => {
+  // Deux dates inversées sont une faute de frappe, pas une plage vide.
+  const [start, end] = draftFrom.value > draftTo.value
+    ? [draftTo.value, draftFrom.value]
+    : [draftFrom.value, draftTo.value]
+  draftFrom.value = start
+  draftTo.value = end
+  from.value = start
+  to.value = end
+  fetchRows()
+}
+
+// --- Dérivés ---------------------------------------------------------------
+const counts = computed(() => ({
+  sauver: rows.value.filter(r => r.segment === 'sauver').length,
+  maximiser: rows.value.filter(r => r.segment === 'maximiser').length,
+  decider: rows.value.filter(r => r.segment === 'decider').length,
+  tous: rows.value.length
+}))
+
+const kpis = computed(() => {
+  const sum = (list, key) => list.reduce((acc, r) => acc + (r[key] || 0), 0)
+  const actionable = rows.value.filter(r => ['sauver', 'maximiser', 'decider'].includes(r.segment))
+  return {
+    remaining: sum(rows.value.filter(r => r.segment === 'maximiser'), 'remaining_potential'),
+    nextSale: sum(actionable, 'next_sale_gain')
+  }
+})
+
+// Marge dormante : ce que rapporterait le remplissage des départs encore à
+// venir. Séparée par moteur, parce qu'un euro GIR est une marge Odysway alors
+// qu'un euro co-remplissage est une commission partenaire fixe.
+const dormant = computed(() => {
+  const future = rows.value.filter(r => r.days_to_departure > 0 && r.remaining_potential > 0)
+  const gir = future.filter(r => !r.co_filling).reduce((acc, r) => acc + r.remaining_potential, 0)
+  const co = future.filter(r => r.co_filling).reduce((acc, r) => acc + r.remaining_potential, 0)
+  return { gir, co, total: gir + co }
+})
+
+const activeTab = computed(() => TABS.find(t => t.id === tab.value) || TABS[0])
+
+const visibleRows = computed(() => {
+  if (tab.value === 'tous') {
+    return rows.value.filter((r) => {
+      if (segmentFilter.value !== 'all' && r.segment !== segmentFilter.value) return false
+      if (motorFilter.value === 'gir' && r.co_filling) return false
+      if (motorFilter.value === 'coremp' && !r.co_filling) return false
+      return true
+    })
+  }
+
+  // Chaque onglet a son propre ordre de lecture : le plus gros potentiel pour
+  // « à maximiser », l'échéance la plus serrée pour « à décider », le départ le
+  // plus proche pour « à garantir ».
+  const list = rows.value.filter(r => r.segment === tab.value)
+  if (tab.value === 'maximiser') {
+    return [...list].sort((a, b) => (b.remaining_potential - a.remaining_potential) || (a.date < b.date ? -1 : 1))
+  }
+  if (tab.value === 'decider') {
+    return [...list].sort((a, b) => a.days_to_decision - b.days_to_decision)
+  }
+  return [...list].sort((a, b) => a.days_to_departure - b.days_to_departure)
+})
+
+const shownRows = computed(() => (showAll.value ? visibleRows.value : visibleRows.value.slice(0, PAGE_SIZE)))
+const hasMore = computed(() => !showAll.value && visibleRows.value.length > PAGE_SIZE)
+
+// Changer d'onglet ou de filtre replie la liste : sinon on hérite du « voir
+// tout » d'une catégorie de 12 lignes sur une catégorie de 600.
+watch([tab, segmentFilter, motorFilter], () => {
+  showAll.value = false
+})
+
+const subtitle = computed(() => {
+  if (loading.value) return 'Chargement…'
+  const n = rows.value.length
+  return `${n} départ${n > 1 ? 's' : ''} · du ${formatFR(from.value)} au ${formatFR(to.value)}`
+})
+
+// --- Rendu -----------------------------------------------------------------
+const formatDay = value => dayjs(value).format('D MMM')
+const formatFR = value => dayjs(value).format('DD/MM/YYYY')
+
+const seatProps = row => ({
+  booked: row.booked,
+  realPax: row.real_pax,
+  partners: row.partners,
+  max: row.max,
+  guaranteed: row.guaranteed
+})
+
+// Le rouge est réservé à l'alerte réelle : l'échéance est dépassée ou tombe
+// aujourd'hui. « Dans 5 jours » est une urgence, pas une alerte — ambre.
+const deadline = (row) => {
+  const days = row.days_to_decision
+  if (days < 0) return { cls: 'bo-tag--crit', text: `dépassée +${-days}j` }
+  if (days === 0) return { cls: 'bo-tag--crit', text: 'aujourd\'hui' }
+  if (days <= 7) return { cls: 'bo-tag--warn', text: `dans ${days}j` }
+  return { cls: '', text: `dans ${days}j` }
+}
+
+const status = (row) => {
+  if (!row.configured) return { cls: '', text: 'Non suivi' }
+  if (row.guaranteed) {
+    return row.co_filling
+      ? { cls: 'bo-tag--part', text: 'Garanti par partenaires' }
+      : { cls: 'bo-tag--ok', text: 'Garanti' }
+  }
+  if (row.segment === 'decider' || row.segment === 'sauver') {
+    return { cls: 'bo-tag--warn', text: `Manque ${row.missing}` }
+  }
+  if (row.segment === 'sans_traction') return { cls: '', text: 'Sans traction' }
+  return { cls: 'bo-tag--info', text: 'Non garanti' }
+}
+
+const openDeparture = (row) => {
+  router.push(`/booking-management/${row.slug}/${row.travel_date_id}`)
+}
+
+onMounted(fetchRows)
+</script>

--- a/app/utils/bookingApi.js
+++ b/app/utils/bookingApi.js
@@ -108,6 +108,8 @@ export const bookingApi = {
   getMarginsStatus: (year = null) =>
     apiRequest(`/booking/margins${encodeQuery(year ? { year } : {})}`),
   getMarginsDashboard: (params = {}) => apiRequest(`/booking/margins/dashboard${encodeQuery(params)}`),
+  // Poste de pilotage : une ligne par départ, déjà segmentée et chiffrée.
+  getMarginsPilotage: (params = {}) => apiRequest(`/booking/margins/pilotage${encodeQuery(params)}`),
   getMarginsDashboardVoyage: (slug, params = {}) =>
     apiRequest(`/booking/margins/dashboard/${encodeURIComponent(slug)}${encodeQuery(params)}`),
   // Returns { rows, seasons, settings } — everything the editor needs in one call.

--- a/server/api/v1/booking/margins/pilotage.get.js
+++ b/server/api/v1/booking/margins/pilotage.get.js
@@ -1,0 +1,266 @@
+import { defineEventHandler, getQuery } from 'h3'
+import dayjs from 'dayjs'
+
+// Poste de pilotage — une ligne par départ, prête à afficher.
+//
+// L'écran Sales trie ~700 départs en quatre catégories d'action et affiche pour
+// chacun ce que rapporterait la prochaine vente. Faire ça côté client
+// imposerait un appel par voyage (grille de marge) : on assemble donc tout ici,
+// en une poignée de requêtes, et la page ne fait que rendre.
+//
+// La note d'implémentation signalait que `min_travelers` et le statut
+// « garanti » manquaient à l'API margins et avaient dû être reconstitués dans
+// la maquette. Ils ne manquent pas : ils vivent dans `travel_dates`, avec
+// `co_filling` pour le co-remplissage. C'est cette table qui fait foi ici.
+//
+// Tous les montants sont en euros (pas en centimes) — comme le reste du module
+// margins, et contrairement au reste de la codebase.
+
+// Fenêtre d'échéance : on considère qu'un départ non garanti doit être tranché
+// 30 jours avant le départ (annulation, bascule en co-remplissage, relance).
+const DECISION_LEAD_DAYS = 30
+// Un départ entre dans « À décider » quand cette échéance est à moins d'une
+// semaine — ou déjà passée.
+const DECISION_ALERT_DAYS = 7
+
+const chunk = (arr, size) => {
+  const out = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const isProdEnv = config.public.environment === 'production' && process.env.NODE_ENV === 'production'
+  if (isProdEnv) requireBookingUser(event)
+
+  const { from, to } = getQuery(event)
+  const dateFrom = from || dayjs().format('YYYY-MM-DD')
+  const dateTo = to || dayjs().add(12, 'month').format('YYYY-MM-DD')
+
+  // 1) Départs de la fenêtre. `min_travelers` / `max_travelers` / `co_filling`
+  //    sont les valeurs réelles, jamais les `displayed_*` : le pilotage
+  //    raisonne sur l'exploitation, pas sur ce que voit le client.
+  const travelDates = await fetchAllPaginated(() =>
+    supabase
+      .from('travel_dates')
+      .select('id, travel_slug, departure_date, return_date, min_travelers, max_travelers, booked_seat, co_filling, margin_override_per_traveler, real_traveler_count_override')
+      .eq('deleted', false)
+      .eq('is_test', false)
+      .gte('departure_date', dateFrom)
+      .lte('departure_date', dateTo)
+      .order('departure_date', { ascending: true }),
+  )
+
+  if (!travelDates.length) {
+    return { rows: [], window: { from: dateFrom, to: dateTo } }
+  }
+
+  // 2) Réservations payantes sur ces dates.
+  const dateIds = travelDates.map(d => d.id)
+  const bookingsChunks = await Promise.all(
+    chunk(dateIds, 100).map(ids =>
+      fetchAllPaginated(() =>
+        supabase
+          .from('booked_dates')
+          .select('travel_date_id, deal_id, booked_places')
+          .in('travel_date_id', ids)
+          .eq('deleted', false)
+          .gt('booked_places', 0),
+      ),
+    ),
+  )
+  const bookings = bookingsChunks.flat()
+
+  // 3) Deals convertis (pipeline 2). Comme dans dashboard.get.js : pas de
+  //    filtre `.in()` sur des milliers d'ids, la ligne est minuscule.
+  const paidDeals = await fetchAllPaginated(() =>
+    supabase
+      .from('activecampaign_deals')
+      .select('id')
+      .eq('pipeline_id', 2),
+  )
+  const paidDealIds = new Set(paidDeals.map(d => Number(d.id)))
+
+  // 4) Configuration de marge, en vrac pour tous les voyages : trois petites
+  //    tables, indexées ensuite par slug. Une requête par voyage donnerait ici
+  //    plusieurs centaines d'aller-retours.
+  const [{ data: marginRows }, { data: seasonRows }, { data: settingsRows }] = await Promise.all([
+    supabase
+      .from('voyage_margins')
+      .select('voyage_slug, pax, margin_per_traveler, year, season_id')
+      .eq('deleted', false)
+      .not('margin_per_traveler', 'is', null),
+    supabase
+      .from('voyage_margin_seasons')
+      .select('voyage_slug, id, label, start_month, start_day, end_month, end_day, sort_order')
+      .eq('deleted', false)
+      .order('sort_order', { ascending: true }),
+    supabase
+      .from('voyage_margin_settings')
+      .select('voyage_slug, config_mode'),
+  ])
+
+  // slug -> pax -> rows
+  const gridBySlug = new Map()
+  for (const r of marginRows || []) {
+    if (!gridBySlug.has(r.voyage_slug)) gridBySlug.set(r.voyage_slug, new Map())
+    const byPax = gridBySlug.get(r.voyage_slug)
+    if (!byPax.has(r.pax)) byPax.set(r.pax, [])
+    byPax.get(r.pax).push(r)
+  }
+
+  const seasonsBySlug = new Map()
+  for (const s of seasonRows || []) {
+    if (!seasonsBySlug.has(s.voyage_slug)) seasonsBySlug.set(s.voyage_slug, [])
+    seasonsBySlug.get(s.voyage_slug).push(s)
+  }
+
+  const modeBySlug = new Map((settingsRows || []).map(r => [r.voyage_slug, r.config_mode]))
+
+  // 5) Places payantes par date.
+  const realPaxByDate = new Map()
+  for (const b of bookings) {
+    if (!paidDealIds.has(Number(b.deal_id))) continue
+    realPaxByDate.set(b.travel_date_id, (realPaxByDate.get(b.travel_date_id) || 0) + Number(b.booked_places || 0))
+  }
+
+  const today = dayjs().startOf('day')
+
+  const rows = travelDates.map((td) => {
+    const slug = td.travel_slug
+    const mode = modeBySlug.get(slug) || 'pax_table'
+    const seasons = seasonsBySlug.get(slug) || []
+    const byPax = gridBySlug.get(slug) || new Map()
+
+    const max = Number(td.max_travelers || 0)
+    const min = Number(td.min_travelers || 0)
+    const partners = Number(td.co_filling || 0)
+    const booked = Number(td.booked_seat || 0)
+
+    const realPax = td.real_traveler_count_override != null
+      ? Number(td.real_traveler_count_override)
+      : (realPaxByDate.get(td.id) || 0)
+
+    // `booked_seat` inclut déjà le co-remplissage (cf. server/utils/booking.js) :
+    // le seuil de garantie se lit donc sur lui, pas sur nos seuls inscrits.
+    const guaranteed = min > 0 && booked >= min
+    // Ce qu'il manque à *nous* pour porter le départ, partenaires exclus. C'est
+    // le chiffre qu'un commercial peut faire bouger.
+    const missing = min > 0 ? Math.max(0, min - realPax) : 0
+    const sellable = max > 0 ? Math.max(0, max - booked) : 0
+    const isCoFilling = partners > 0
+
+    const daysToDeparture = dayjs(td.departure_date).startOf('day').diff(today, 'day')
+    const daysToDecision = daysToDeparture - DECISION_LEAD_DAYS
+
+    // --- Marge -------------------------------------------------------------
+    // Un départ « suivi » est un départ dont on sait chiffrer la prochaine
+    // vente. Sans grille exploitable, il n'entre dans aucun onglet d'action et
+    // n'apparaît que dans le tableau exhaustif, marqué « non suivi ».
+    const marginAt = (pax) => {
+      if (pax <= 0) return 0
+      if (td.margin_override_per_traveler != null) return Number(td.margin_override_per_traveler) * pax
+      if (mode === 'excluded') return null
+      const resolved = margins.resolveBaseFromRows({
+        rows: byPax.get(pax) || [],
+        seasons,
+        departureDate: td.departure_date,
+      })
+      return resolved.value == null ? null : Number(resolved.value) * pax
+    }
+
+    const currentTotal = marginAt(realPax)
+    // La grille peut être trouée : ce qui compte est de savoir chiffrer le pas
+    // suivant, pas d'avoir toute la colonne.
+    const nextTotal = sellable >= 1 ? marginAt(realPax + 1) : null
+    const configured = mode !== 'excluded'
+      && (td.margin_override_per_traveler != null || byPax.size > 0)
+
+    const nextSaleGain = (currentTotal != null && nextTotal != null)
+      ? Math.max(0, nextTotal - currentTotal)
+      : 0
+
+    // Potentiel restant : ce que rapporterait le remplissage jusqu'à la
+    // capacité, à partir de nos inscrits actuels.
+    const target = Math.min(max || realPax, realPax + sellable)
+    const targetTotal = marginAt(target)
+    const remaining = (currentTotal != null && targetTotal != null)
+      ? Math.max(0, targetTotal - currentTotal)
+      : 0
+
+    // Prochain palier rentable : entre la position actuelle et la cible, le pax
+    // dont le saut marginal est le plus gros. La marge d'un siège pair vaut à
+    // peu près le double d'un impair (effet chambre double), donc ce palier
+    // tombe presque toujours sur un pair — c'est là qu'il faut pousser.
+    let step = null
+    let stepSales = 0
+    let stepGain = 0
+    if (currentTotal != null) {
+      let prevTotal = currentTotal
+      let best = 0
+      for (let p = realPax + 1; p <= target; p++) {
+        const total = marginAt(p)
+        if (total == null) continue
+        const jump = total - prevTotal
+        if (jump > best) {
+          best = jump
+          step = p
+          stepSales = p - realPax
+          stepGain = total - currentTotal
+        }
+        prevTotal = total
+      }
+    }
+
+    // --- Segmentation ------------------------------------------------------
+    // Ordre de priorité opérationnelle : sécuriser, puis optimiser, puis
+    // arbitrer. Un départ n'appartient qu'à un seul onglet d'action.
+    let segment
+    if (!configured) {
+      segment = 'non_suivi'
+    }
+    else if (!guaranteed && realPax >= 1 && missing === 1) {
+      // Se confirme à la prochaine vente : le meilleur euro à aller chercher.
+      segment = 'sauver'
+    }
+    else if (guaranteed && realPax >= 1 && !isCoFilling && sellable >= 1 && remaining > 0) {
+      segment = 'maximiser'
+    }
+    else if (!guaranteed && !isCoFilling && daysToDecision <= DECISION_ALERT_DAYS) {
+      segment = 'decider'
+    }
+    else if (!guaranteed && realPax === 0) {
+      segment = 'sans_traction'
+    }
+    else {
+      segment = 'non_garanti'
+    }
+
+    return {
+      travel_date_id: td.id,
+      slug,
+      date: td.departure_date,
+      days_to_departure: daysToDeparture,
+      days_to_decision: daysToDecision,
+      min,
+      max,
+      booked,
+      real_pax: realPax,
+      partners,
+      sellable,
+      missing,
+      guaranteed,
+      co_filling: isCoFilling,
+      configured,
+      next_sale_gain: nextSaleGain,
+      remaining_potential: remaining,
+      step,
+      step_sales: stepSales,
+      step_gain: Math.max(0, stepGain),
+      segment,
+    }
+  })
+
+  return { rows, window: { from: dateFrom, to: dateTo } }
+})


### PR DESCRIPTION
Implémente la maquette `BMS_Poste_Pilotage_GIR_v2_2026-08-12`, en deux temps : la bascule du système visuel, puis le nouvel écran.

## 1. Système visuel — tout le BMS passe sur la palette de la maquette

Le backoffice était bâti sur le teal de marque. La maquette propose un langage différent : accent indigo, neutres froids, surfaces ombrées, rayons généreux, pastilles arrondies. Le choix retenu est de basculer **l'ensemble des 11 écrans** plutôt que de laisser le poste de pilotage détonner.

| | avant | après |
|---|---|---|
| Accent | teal `#2B4C52` | indigo `#5B5BD6` |
| Fond de page | `#F1F4F4` | `#F5F6F8` |
| Cartes | plates, rayon 5px | ombre basse, rayon 12px |
| Tags d'état | carrés, capitales | pastilles arrondies |
| Rail | `#12222A`, accent teal | `#0C1922`, accent vert Odysway |

Deux points méritent l'attention du relecteur :

**Trois valeurs par sémantique au lieu d'une.** La maquette n'expose que l'aplat vif (`--ok: #12A150`), qui ne tient pas 4,5:1 en texte. Chaque famille existe donc en `--bo-x` (aplat : barres, bandes, filets), `--bo-x-soft` (fond de pastille) et `--bo-x-ink` (texte). Sans cette séparation, « reste dû 6 200 € » tombait à 2,2:1. Une famille violette est ajoutée pour le co-remplissage, qui n'est ni un état sain ni une alerte.

**Le thème sombre est dérivé, pas fourni.** La maquette ne couvre que le clair. Deux écarts sont assumés et commentés sur place : les champs se creusent sous la carte (règle inverse du clair, sinon ils y disparaissent), et les fonds `-soft` sont recalculés à 16 % de l'aplat dans la surface.

## 2. Poste de pilotage — `/booking-management/sales`

Nouvel écran, en tête du rail sous un groupe « Pilotage ». Reprend les règles UX de la maquette : hero GIR (marge dormante, GIR vs co-remplissage), encart règle du siège pair, sélecteur de plage appliqué côté serveur, quatre onglets dans l'ordre opérationnel **À garantir → À maximiser → À décider → Tous les départs** avec la couleur de catégorie sur l'onglet actif, KPI recalculés sur la plage, libellé « Pays - CODE » avec titre discret, barre de sièges à repères pairs, rouge réservé aux échéances dépassées, filtres segment et moteur.

### Sur le point n°2 de la note d'implémentation

La note signalait que `min_travelers` et le statut « garanti » manquaient à l'API margins, avaient dû être reconstitués dans la maquette, et laissaient ~39 voyages en « non suivi ».

Ils ne manquent pas : ils sont dans `travel_dates`, avec `co_filling` pour le co-remplissage. Le nouvel endpoint `GET /api/v1/booking/margins/pilotage` les lit directement. Un départ ne reste « non suivi » que s'il n'a réellement pas de grille de marge exploitable.

L'endpoint assemble les lignes côté serveur — quelques requêtes au lieu d'un appel de grille par voyage — et calcule `totalAt`, prochaine vente, potentiel restant, prochain palier rentable et la segmentation. `DECISION_LEAD_DAYS = 30` et `DECISION_ALERT_DAYS = 7` y sont nommés plutôt qu'enfouis dans une condition.

## Vérification

`npm run dev` ne démarre pas dans ce repo : `cms/sanity.config.ts` importe `sanity`, qui n'est ni dans `package.json` ni dans le lockfile, et `@nuxtjs/sanity` charge cette config à l'init de Nuxt. Problème préexistant, sans rapport avec cette PR.

À défaut, la vérification a été faite ainsi :

- SCSS compilé par `sass.compile`, les 7 SFC touchés par `@vue/compiler-sfc` (`parse` + `compileTemplate` + `compileScript`), le handler par `node --check` — tout passe.
- Banc d'essai statique chargeant le CSS réellement compilé, capturé dans les deux thèmes via Chrome headless (CDP). A révélé un vrai défaut : le code voyage se coupait en fin de ligne (`Tanzanie - AF-` / `TZA-01`), ce qui lui retire sa fonction d'identifiant. Corrigé par `white-space: nowrap` et une largeur plancher sur les tables denses.
- Les composants existants (notices, jauges de remplissage, panneau argent, journal d'activité, bloc `displayed_*`, lignes supprimées) sont passés au même banc d'essai : pas de régression dans les deux thèmes.

`npm run lint` est cassé dans ce repo indépendamment de cette PR (voir la config ESLint, qui exige `.nuxt/eslint.config.mjs`).

## Reste à faire

Le bouton « Prospects » pointe encore sur une recherche ActiveCampaign par titre de voyage, comme dans la maquette. Le rapprochement réel — compteurs par type, déduplication, liste filtrée sur le départ — dépend de la spéc `BMS_Spec_ActiveCampaign_Prospects`, qui n'était pas jointe. Signalé en commentaire dans `BoDepartureActions.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
