### PR TITLE
fix(tracking): fiabiliser add_payment_info / pose option et compléter la whitelist CSP

### DIFF
--- a/app/components/Funnel/Steps/PaymentRedirect.vue
+++ b/app/components/Funnel/Steps/PaymentRedirect.vue
@@ -345,7 +345,7 @@
 import { mdiCalendarOutline, mdiChevronDown, mdiArrowDownBold } from '@mdi/js'
 import { bookingApi, getApiErrorMessage } from '~/utils/bookingApi'
 
-const { trackAddPaymentInfo, trackReservationPoseOption } = useGtmTracking()
+const { trackAddPaymentInfo, trackReservationPoseOption, getCountryFromPhone } = useGtmTracking()
 
 const { page, voyage } = defineProps(['page', 'voyage', 'currentStep', 'ownStep'])
 const route = useRoute()
@@ -358,6 +358,34 @@ const emit = defineEmits(['previous'])
 const model = defineModel()
 const { updateDeal, bookedId: composableBookedId, kickstartLoading } = useStepperDeal()
 const { reportApiError, setContext } = useFunnelReporter()
+
+/**
+ * user_data block shared by every funnel event fired from this step.
+ */
+const buildUserData = () => ({
+  user_id: model.value.email,
+  user_mail: model.value.email,
+  user_phone: model.value.phone,
+  user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
+})
+
+/**
+ * Fire add_payment_info as soon as the user clicks a payment method.
+ *
+ * It used to be pushed only *after* /api/v1/stripe (or /alma) had returned a
+ * checkout link, so every failed or slow session creation silently swallowed
+ * the event — which is why the payment-method clicks stopped showing up.
+ * The push now happens on the click itself, and the returned promise lets the
+ * redirect wait for GTM's eventCallback so the tags still leave the browser
+ * before `window.location.href` unloads the page.
+ *
+ * @returns {Promise<void>} resolves once the tags fired (or on timeout)
+ */
+const trackPaymentMethodClick = (paymentType) => {
+  return new Promise((resolve) => {
+    trackAddPaymentInfo(voyage, model.value, paymentType, buildUserData(), resolve)
+  })
+}
 const { addSingleParam } = useParams()
 
 const isSurMesure = computed(() => voyage.availabilityTypes?.includes('custom'))
@@ -431,6 +459,7 @@ const stripePay = async () => {
   paymentError.value = null
   loadingSession.value = true
   redirectingToStripe.value = true
+  const tagsFired = trackPaymentMethodClick('stripe')
   try {
     const bookedId = route.query.booked_id || composableBookedId.value
     const contact = {
@@ -459,20 +488,13 @@ const stripePay = async () => {
       body: JSON.stringify(dataForStripeSession),
     })
     if (checkoutLink) {
-      const { getCountryFromPhone } = useGtmTracking()
-      const userData = {
-        user_id: model.value.email,
-        user_mail: model.value.email,
-        user_phone: model.value.phone,
-        user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
-      }
-      // Redirect from the tracking callback: pushing and navigating in the
-      // same tick unloads the page before the tags fire, which is what made
-      // the Meta CB-click event disappear. The callback is guaranteed to run
-      // (timeout fallback), so the payment flow never waits on analytics.
-      trackAddPaymentInfo(voyage, model.value, 'stripe', userData, () => {
-        window.location.href = checkoutLink
-      })
+      // Wait for the click-time push to have fired its tags: pushing and
+      // navigating in the same tick unloads the page before the tags leave the
+      // browser, which is what made the Meta CB-click event disappear. The
+      // promise always settles (timeout fallback), so the payment flow never
+      // waits on analytics.
+      await tagsFired
+      window.location.href = checkoutLink
     }
     else {
       redirectingToStripe.value = false
@@ -503,6 +525,7 @@ const almaPay = async () => {
   paymentError.value = null
   loadingSession.value = true
   redirectingToAlma.value = true
+  const tagsFired = trackPaymentMethodClick('alma')
   try {
     const dataForAlmaSession = {
       paymentType: route.query.type,
@@ -529,16 +552,8 @@ const almaPay = async () => {
       body: JSON.stringify(dataForAlmaSession),
     })
     if (checkoutLink.url) {
-      const { getCountryFromPhone } = useGtmTracking()
-      const userData = {
-        user_id: model.value.email,
-        user_mail: model.value.email,
-        user_phone: model.value.phone,
-        user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
-      }
-      trackAddPaymentInfo(voyage, model.value, 'alma', userData, () => {
-        window.location.href = checkoutLink.url
-      })
+      await tagsFired
+      window.location.href = checkoutLink.url
     }
     else {
       redirectingToAlma.value = false
@@ -586,6 +601,12 @@ const book = async () => {
       userMessage: 'Impossible de poser l\'option pour le moment. Veuillez réessayer.',
     })
   }
+  // Push reservation_pose_option before the CRM/Slack side effects. It used to
+  // sit after an awaited, unguarded $fetch to /api/v1/slack/notification that
+  // only runs in production — so a single Slack hiccup rejected book() and the
+  // dataLayer event (and the redirect) never happened.
+  trackReservationPoseOption(voyage, model.value, buildUserData())
+
   const dealData = {
     stage: '27',
     currentStep: 'A posé une option',
@@ -596,20 +617,12 @@ const book = async () => {
   }
   updateDeal(dealData)
   if (config.public.environment === 'production') {
-    await $fetch('/api/v1/slack/notification', {
+    $fetch('/api/v1/slack/notification', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...dealData, bookedId: route.query.booked_id }),
-    })
+    }).catch(err => console.error('[PaymentRedirect] slack notification failed', err))
   }
-  const { getCountryFromPhone } = useGtmTracking()
-  const userData = {
-    user_id: model.value.email,
-    user_mail: model.value.email,
-    user_phone: model.value.phone,
-    user_country: getCountryFromPhone(model.value.phone) || 'Unknown',
-  }
-  trackReservationPoseOption(voyage, model.value, userData)
   await navigateTo(`/confirmation?voyage=${voyage.slug}&isoption=true`)
 }
 </script>

--- a/server/middleware/csp-report-only.ts
+++ b/server/middleware/csp-report-only.ts
@@ -5,18 +5,72 @@
 // would break in production before switching to an enforcing policy in
 // nuxt.config.ts (security.headers.contentSecurityPolicy).
 //
+// Console noise is not free even in Report-Only: Google Tag Assistant reads the
+// console and reports "Content Security Policy (CSP) bloque les scripts Google"
+// as a hard error as soon as it sees a googletagmanager/google-analytics
+// violation, report-only or not. The whitelist below was rebuilt from the
+// violations actually observed in production (home, page voyage, checkout) so
+// the console stays clean and the policy is safe to enforce later.
+//
 // Once the console is clean in production, move these directives into
 // nuxt-security's contentSecurityPolicy and drop this middleware.
 
+// GTM server-side tagging (custom domain) — loader + collector + its cookie
+// pixel and iframe.
+const SST = [
+  'https://load.sst.odysway.com',
+  'https://sst.odysway.com',
+]
+
+// Google Ads / Analytics / Tag Manager. See
+// https://developers.google.com/tag-platform/security/guides/csp
+// gstatic serves the Ads call-tracking + web-conversion loaders, doubleclick
+// the remarketing pixels, googleadservices the conversion endpoints.
+const GOOGLE_SCRIPT = [
+  'https://www.googletagmanager.com',
+  'https://*.googletagmanager.com',
+  'https://www.google-analytics.com',
+  'https://ssl.google-analytics.com',
+  'https://www.gstatic.com',
+  'https://www.googleadservices.com',
+  'https://*.g.doubleclick.net',
+]
+
+// Google Ads remarketing hits every ccTLD of the visitor's region. Odysway
+// sells in FR/BE/CH/LU/CA, plus the .com fallback.
+const GOOGLE_CCTLD = [
+  'https://www.google.com',
+  'https://www.google.fr',
+  'https://www.google.be',
+  'https://www.google.ch',
+  'https://www.google.lu',
+  'https://www.google.ca',
+]
+
+const GOOGLE_COLLECT = [
+  'https://www.google-analytics.com',
+  'https://*.google-analytics.com',
+  'https://*.analytics.google.com',
+  'https://*.googletagmanager.com',
+  'https://www.googleadservices.com',
+  'https://*.doubleclick.net',
+  ...GOOGLE_CCTLD,
+]
+
 const CSP_DIRECTIVES = [
   'default-src \'self\'',
-  // GTM/SST, Stripe.js and Hotjar inject inline + external scripts; Vuetify/Nuxt need inline.
-  'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://www.googletagmanager.com https://load.sst.odysway.com https://sst.odysway.com https://js.stripe.com https://*.hotjar.com',
+  // script-src-elem is set explicitly: without it the browser falls back to
+  // script-src and reports the directive name Tag Assistant flags.
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${[...SST, ...GOOGLE_SCRIPT].join(' ')} https://js.stripe.com https://*.hotjar.com https://app.cal.com https://tally.so`,
+  `script-src-elem 'self' 'unsafe-inline' ${[...SST, ...GOOGLE_SCRIPT].join(' ')} https://js.stripe.com https://*.hotjar.com https://app.cal.com https://tally.so`,
   'style-src \'self\' \'unsafe-inline\'',
-  'img-src \'self\' data: blob: https://cdn.sanity.io https://*.sanity.io https://www.googletagmanager.com https://*.google-analytics.com https://*.hotjar.com',
+  // GA4/Ads/Meta send a large share of their hits as pixel <img> requests.
+  `img-src 'self' data: blob: https://cdn.sanity.io https://*.sanity.io ${[...SST, ...GOOGLE_COLLECT].join(' ')} https://*.hotjar.com https://www.facebook.com https://*.facebook.com`,
   'font-src \'self\' data: https://*.hotjar.com',
-  'connect-src \'self\' https://*.sanity.io https://*.algolia.net https://*.algolianet.com https://www.google-analytics.com https://load.sst.odysway.com https://sst.odysway.com https://*.hotjar.com wss://*.hotjar.com',
-  'frame-src \'self\' https://js.stripe.com https://hooks.stripe.com https://www.googletagmanager.com',
+  `connect-src 'self' https://*.sanity.io https://*.algolia.net https://*.algolianet.com ${[...SST, ...GOOGLE_COLLECT].join(' ')} https://*.hotjar.com wss://*.hotjar.com https://app.cal.com https://tally.so`,
+  // sst.odysway.com iframes itself for cross-domain cookie sync; doubleclick
+  // and googletagmanager frame the Ads conversion pings.
+  `frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://www.googletagmanager.com ${SST.join(' ')} https://*.doubleclick.net https://app.cal.com https://tally.so https://www.youtube.com https://www.youtube-nocookie.com`,
   'frame-ancestors \'self\'',
   'base-uri \'self\'',
   'form-action \'self\'',


### PR DESCRIPTION
Trois problèmes remontés par Tag Assistant sur la prod. Ils ont trois causes distinctes — et la première n'est pas celle que Tag Assistant annonce.

## 1. « CSP bloque les scripts Google » — le message est réel, le blocage ne l'est pas

La politique est envoyée en **`Content-Security-Policy-Report-Only`** (`contentSecurityPolicy: false` côté nuxt-security). En Report-Only le navigateur ne bloque rien, il journalise. Mais Tag Assistant lit la console et remonte une erreur dure dès qu'il voit une violation Google, report-only ou pas.

Cela dit la whitelist était réellement incomplète. Violations relevées sur la prod (accueil, page voyage, checkout) :

| Directive | Origines manquantes |
|---|---|
| `script-src` | `www.gstatic.com` (call-tracking + wcm/loader), `googleads.g.doubleclick.net` |
| `connect-src` | `www.google.com`, `www.google.fr`, `ad.doubleclick.net`, `www.googleadservices.com` |
| `img-src` | `www.google.com/.fr` (1p-user-list, ga-audiences), `region1.analytics.google.com`, `sst.odysway.com`, `www.facebook.com` |
| `frame-src` | **`sst.odysway.com`** — l'iframe du tagging server-side |

`script-src-elem` est désormais déclaré explicitement : son absence est la directive que Tag Assistant cite mot pour mot.

⚠️ **Sans ce correctif, un passage en enforce faisait tomber l'iframe SST et les pixels Ads/Meta.**

## 2. `add_payment_info` perdu quand la session de paiement échoue

L'event n'était poussé qu'**après** le retour de `/api/v1/stripe` (ou `/alma`). Session lente, 500 ou timeout → aucun event, alors que l'utilisateur a bien cliqué.

Le push part maintenant **au clic**, et la redirection attend la promesse d'`eventCallback` (fallback timeout 1,5 s) pour que les tags quittent le navigateur avant `window.location.href` — le comportement introduit par a38adc10 est conservé.

## 3. `reservation_pose_option` avalé par la notification Slack

Dans `book()`, le `$fetch` vers `/api/v1/slack/notification` était **awaité sans `.catch()`** et ne s'exécute **qu'en production** — soit exactement l'environnement où `pushToDataLayer` est actif. Un seul échec Slack rejetait `book()` et emportait l'event *et* la redirection vers `/confirmation`, alors que l'option était déjà posée en base et le deal mis à jour.

Le fetch devient non bloquant, et le push passe avant les effets de bord.

## Vérification

Tunnel réel en local, réseau stubbé (**aucune écriture AC/Supabase**), en comparant code d'origine et code corrigé :

| Scénario | Code d'origine | Code corrigé |
|---|---|---|
| Session Stripe OK | event OK | `add_payment_info` + redirection ✅ |
| **Stripe 500** | **dataLayer vide** | `add_payment_info` ✅ |
| **Alma 500** | **dataLayer vide** | `add_payment_info` ✅ |
| **Slack 500 (option)** | **dataLayer vide + blocage sur `/checkout`** | `reservation_pose_option` ✅ + `/confirmation` |

Payloads vérifiés : `payment_type: "stripe"`, `value: 1190`, 1 item, `user_country: "France"` / option `value: 1190`, `user_data` présent.

Whitelist CSP validée par script : les 15 origines qui violaient passent, et 7 témoins (Stripe, GTM, Sanity, SST) ne régressent pas. Header relu sur le serveur de dev.

`npx eslint` : 0 erreur (6 warnings `require-prop-types` préexistants).

## Points d'attention pour la revue

- **Changement de sémantique analytics** : `add_payment_info` se déclenche désormais aussi quand le paiement n'aboutit pas. C'est la définition GA4 standard (« l'utilisateur a choisi un moyen de paiement »), mais les volumes vont monter — à valider avec la personne qui exploite la donnée.
- **ccTLD Google** : la liste couvre FR/BE/CH/LU/CA + `.com`. Un visiteur d'un autre pays déclenchera encore une violation (`google.de`, etc.) — à compléter selon les marchés.
- La CSP reste en **Report-Only** : ce correctif ne peut rien casser en prod, il prépare le passage en enforce.
- Le chemin de pose d'option de l'**étape 1** (`Details.vue`) pousse déjà l'event correctement — son fetch Slack avait un `.catch()` — et reste **inchangé**.
- Les stubs simulent les pannes de Stripe/Alma/Slack ; ils prouvent que *si* l'un échoue l'event n'est plus perdu, pas laquelle des trois pannes se produit réellement en prod. Les logs Slack et le taux d'erreur sur `/api/v1/stripe` diront laquelle.

## Effet de bord bénéfique

Quand Slack échouait, le client restait **bloqué sur le checkout alors que son option était déjà posée en base** — et pouvait recliquer pour tomber sur « La date est déjà réservée ». Le correctif règle ça aussi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)